### PR TITLE
Use fivetran's library structure

### DIFF
--- a/cmd/internal/server/handlers/check_connection.go
+++ b/cmd/internal/server/handlers/check_connection.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"context"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 )
 
 type CheckConnection struct{}

--- a/cmd/internal/server/handlers/configuration_form.go
+++ b/cmd/internal/server/handlers/configuration_form.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"context"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 )
 
 type ConfigurationForm struct{}

--- a/cmd/internal/server/handlers/logger.go
+++ b/cmd/internal/server/handlers/logger.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )

--- a/cmd/internal/server/handlers/logger_test.go
+++ b/cmd/internal/server/handlers/logger_test.go
@@ -7,7 +7,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/cmd/internal/server/handlers/planetscale_edge_database.go
+++ b/cmd/internal/server/handlers/planetscale_edge_database.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/planetscale/psdb/auth"
 	grpcclient "github.com/planetscale/psdb/core/pool"
 	clientoptions "github.com/planetscale/psdb/core/pool/options"

--- a/cmd/internal/server/handlers/planetscale_edge_database_test.go
+++ b/cmd/internal/server/handlers/planetscale_edge_database_test.go
@@ -8,7 +8,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/query"
 
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 

--- a/cmd/internal/server/handlers/schema.go
+++ b/cmd/internal/server/handlers/schema.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"context"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 )
 
 type Schema struct{}

--- a/cmd/internal/server/handlers/sync.go
+++ b/cmd/internal/server/handlers/sync.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"vitess.io/vitess/go/sqltypes"

--- a/cmd/internal/server/handlers/sync_state.go
+++ b/cmd/internal/server/handlers/sync_state.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 )
 
 type SyncState struct {

--- a/cmd/internal/server/handlers/sync_state_test.go
+++ b/cmd/internal/server/handlers/sync_state_test.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"testing"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/internal/server/handlers/sync_test.go
+++ b/cmd/internal/server/handlers/sync_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/internal/server/handlers/test_types.go
+++ b/cmd/internal/server/handlers/test_types.go
@@ -9,7 +9,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"google.golang.org/grpc"
 )
 

--- a/cmd/internal/server/handlers/types.go
+++ b/cmd/internal/server/handlers/types.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/planetscale/psdb/core/codec"
 )
 

--- a/cmd/internal/server/server.go
+++ b/cmd/internal/server/server.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"time"
 
+	fivetran_sdk "github.com/planetscale/fivetran-proto/go"
+
 	"github.com/google/uuid"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/pkg/errors"
-	fivetran_sdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
 	"github.com/planetscale/fivetran-source/cmd/internal/server/handlers"
 )
 

--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -20,7 +20,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/cmd/internal/server/types.go
+++ b/cmd/internal/server/types.go
@@ -3,7 +3,7 @@ package server
 import (
 	"context"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/planetscale/fivetran-source/cmd/internal/server/handlers"
 )
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 
-	fivetransdk "github.com/planetscale/fivetran-proto/proto/fivetransdk/v1alpha1"
+	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/planetscale/fivetran-source/cmd/internal/server"
 	"google.golang.org/grpc"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/planetscale/airbyte-source v1.12.0
-	github.com/planetscale/fivetran-proto v0.0.0-20230328191619-a7e5ff4ae556
+	github.com/planetscale/fivetran-proto v0.0.0-20230410214623-a81ba896d0e0
 	github.com/planetscale/psdb v0.0.0-20220429000526-e2a0e798aaf3
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.53.0

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,8 @@ github.com/planetscale/airbyte-source v1.12.0 h1:R2wSOgnbMC1PKee05YsdkGUAsXLGi8b
 github.com/planetscale/airbyte-source v1.12.0/go.mod h1:M6/mfslkVMX213JtAP7+SJoFqTxYODDVWDhoQ+WMuK4=
 github.com/planetscale/fivetran-proto v0.0.0-20230328191619-a7e5ff4ae556 h1:vq3LfQezFA6qf++C7BuOGUTcPnTPIT+PaTsXjkqOZ9A=
 github.com/planetscale/fivetran-proto v0.0.0-20230328191619-a7e5ff4ae556/go.mod h1:jP6PXMux7WNsn+ylpKab+xIEQ6wstSnBA2KQDdkCrYc=
+github.com/planetscale/fivetran-proto v0.0.0-20230410214623-a81ba896d0e0 h1:S4ziUF++0Da0kj/TfB9frrmzmvGzv8uEQ+xF4geYMjQ=
+github.com/planetscale/fivetran-proto v0.0.0-20230410214623-a81ba896d0e0/go.mod h1:jP6PXMux7WNsn+ylpKab+xIEQ6wstSnBA2KQDdkCrYc=
 github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a h1:y0OpQ4+5tKxeh9+H+2cVgASl9yMZYV9CILinKOiKafA=
 github.com/planetscale/psdb v0.0.0-20220429000526-e2a0e798aaf3 h1:oEgD8tPIpxrTTEvVEDsY9pjkJOiqmpOE5kCGnTIGyHM=
 github.com/planetscale/psdb v0.0.0-20220429000526-e2a0e798aaf3/go.mod h1:h30/ekyWqcvoiep4efR5nsNaJxGvyRN+9oTirJg4FRE=


### PR DESCRIPTION
Fivetran published their proto files in a private repository with a different structure than `planetscale/fivetran-proto`. 
This PR makes the source repo build with this new import structure. 