### PR TITLE
Send Updates & Deletes from ConnectClient

### DIFF
--- a/cmd/internal/server/handlers/sync.go
+++ b/cmd/internal/server/handlers/sync.go
@@ -32,7 +32,7 @@ func (s *Sync) Handle(psc *lib.PlanetScaleSource, db *lib.ConnectClient, logger 
 			if !ok {
 				return status.Error(codes.Internal, fmt.Sprintf("Unable to read state for stream %v", stateKey))
 			}
-			onRow := func(res *sqltypes.Result) error {
+			onRow := func(res *sqltypes.Result, opType lib.Operation) error {
 				return logger.Record(res, ks, table)
 			}
 
@@ -50,7 +50,7 @@ func (s *Sync) Handle(psc *lib.PlanetScaleSource, db *lib.ConnectClient, logger 
 					return status.Error(codes.Internal, fmt.Sprintf("invalid cursor for stream %v, failed with [%v]", stateKey, err))
 				}
 				columns := includedColumns(table)
-				sc, err := (*db).Read(ctx, logger, *psc, table.TableName, columns, tc, onRow, onCursor)
+				sc, err := (*db).Read(ctx, logger, *psc, table.TableName, columns, tc, onRow, onCursor, nil)
 				if err != nil {
 					return status.Error(codes.Internal, fmt.Sprintf("failed to download rows for table : %s", table.TableName))
 				}

--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -281,7 +281,7 @@ func TestUpdateReturnsRows(t *testing.T) {
 			ReadFn: func(ctx context.Context, logger lib.DatabaseLogger, ps lib.PlanetScaleSource, tableName string, columns []string, tc *psdbconnect.TableCursor, onResult lib.OnResult, onCursor lib.OnCursor) (*lib.SerializedCursor, error) {
 				assert.Equal(t, "customers", tableName)
 				assert.NotNil(t, columns)
-				onResult(allTypesResult)
+				onResult(allTypesResult, lib.OpType_Insert)
 				return nil, nil
 			},
 		}

--- a/lib/test_types.go
+++ b/lib/test_types.go
@@ -114,7 +114,7 @@ func (tcc *TestConnectClient) CanConnect(ctx context.Context, ps PlanetScaleSour
 	return errors.New("CanConnect is Unimplemented")
 }
 
-func (tcc *TestConnectClient) Read(ctx context.Context, logger DatabaseLogger, ps PlanetScaleSource, tableName string, columns []string, lastKnownPosition *psdbconnect.TableCursor, onResult OnResult, onCursor OnCursor) (*SerializedCursor, error) {
+func (tcc *TestConnectClient) Read(ctx context.Context, logger DatabaseLogger, ps PlanetScaleSource, tableName string, columns []string, lastKnownPosition *psdbconnect.TableCursor, onResult OnResult, onCursor OnCursor, onUpdate OnUpdate) (*SerializedCursor, error) {
 	if tcc.ReadFn != nil {
 		return tcc.ReadFn(ctx, logger, ps, tableName, columns, lastKnownPosition, onResult, onCursor)
 	}

--- a/lib/types.go
+++ b/lib/types.go
@@ -3,11 +3,25 @@ package lib
 import (
 	"encoding/base64"
 
+	"vitess.io/vitess/go/sqltypes"
+
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/planetscale/psdb/core/codec"
 )
 
+type Operation int64
+
+const (
+	OpType_Insert Operation = iota
+	OpType_Update
+	OpType_Delete
+)
+
+type UpdatedRow struct {
+	Before *sqltypes.Result
+	After  *sqltypes.Result
+}
 type MysqlColumn struct {
 	Name         string
 	Type         string


### PR DESCRIPTION
This PR is in support of sending updates & deletes from a PlanetScale database to fivetran. 
It accomplishes this by using the recent changes to edge to send Updates & Deletes to callers of the Sync API. 

I have made some changes to existing types : 
`OnResult` func now takes an `Operation` value that can be one of the following : 
https://github.com/planetscale/fivetran-source/blob/e5d3f4cb8ef10e9f21b3446999d39ea26143f456/lib/types.go#L15-L19

And since Updates have both a `Before` & `After` Row, we have a special handler for it. 
https://github.com/planetscale/fivetran-source/blob/e5d3f4cb8ef10e9f21b3446999d39ea26143f456/lib/connect_client.go#L29

There's no support for consuming this on the caller side yet, that's coming in a follow-up PR.