### PR TITLE
Send Inserts, Updates & Deletes to FiveTran

### DIFF
--- a/cmd/internal/server/handlers/schema_aware_serializer_test.go
+++ b/cmd/internal/server/handlers/schema_aware_serializer_test.go
@@ -136,7 +136,8 @@ func TestCanSerializeUpdate(t *testing.T) {
 		table.Columns[f.Name] = true
 	}
 
-	after, s, err := generateTestRecord("YayavaramNarasimha")
+	after, _, err := generateTestRecord("YayavaramNarasimha")
+	assert.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
 		err = l.Update(&lib.UpdatedRow{

--- a/cmd/internal/server/handlers/schema_aware_serializer_test.go
+++ b/cmd/internal/server/handlers/schema_aware_serializer_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/planetscale/fivetran-source/lib"
+
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	fivetransdk "github.com/planetscale/fivetran-proto/go"
@@ -15,7 +17,7 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
-func TestCanSerializeRecord(t *testing.T) {
+func TestCanSerializeInsert(t *testing.T) {
 	timestamp := "2006-01-02 15:04:05"
 	row, s, err := generateTestRecord()
 	require.NoError(t, err)
@@ -37,7 +39,7 @@ func TestCanSerializeRecord(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		err = l.Record(row, schema, table)
+		err = l.Record(row, schema, table, lib.OpType_Insert)
 		assert.NoError(t, err)
 		assert.NotNil(t, tl.lastResponse)
 	}
@@ -48,6 +50,7 @@ func TestCanSerializeRecord(t *testing.T) {
 	operationRecord, ok := operation.Operation.Op.(*fivetransdk.Operation_Record)
 	assert.Truef(t, ok, "recordResponse Operation.Op is not of type %s", "Operation_Record")
 
+	assert.Equal(t, fivetransdk.OpType_UPSERT, operationRecord.Record.Type)
 	data := operationRecord.Record.Data
 	assert.NotNil(t, data)
 
@@ -70,6 +73,46 @@ func TestCanSerializeRecord(t *testing.T) {
 	dt, err := time.Parse("2006-01-02 15:04:05", "2021-01-19 03:14:07.999999")
 	require.NoError(t, err)
 	assert.Equal(t, timestamppb.New(dt).Nanos, data["datetime_value"].GetNaiveDatetime().Nanos)
+}
+
+func TestCanSerializeDelete(t *testing.T) {
+	row, s, err := generateTestRecord()
+	require.NoError(t, err)
+	tl := &testLogSender{}
+	l := NewSchemaAwareSerializer(tl, "", false, &fivetransdk.SchemaList{Schemas: []*fivetransdk.Schema{s}})
+
+	schema := &fivetransdk.SchemaSelection{
+		Included:   true,
+		SchemaName: s.Name,
+	}
+	table := &fivetransdk.TableSelection{
+		TableName: "Customers",
+		Included:  true,
+		Columns:   map[string]bool{},
+	}
+
+	for _, f := range row.Fields {
+		table.Columns[f.Name] = true
+	}
+
+	for i := 0; i < 3; i++ {
+		err = l.Record(row, schema, table, lib.OpType_Delete)
+		assert.NoError(t, err)
+		assert.NotNil(t, tl.lastResponse)
+	}
+
+	operation, ok := tl.lastResponse.Response.(*fivetransdk.UpdateResponse_Operation)
+	require.Truef(t, ok, "recordResponse Operation is not of type %s", "UpdateResponse_Operation")
+
+	operationRecord, ok := operation.Operation.Op.(*fivetransdk.Operation_Record)
+	assert.Truef(t, ok, "recordResponse Operation.Op is not of type %s", "Operation_Record")
+
+	assert.Equal(t, fivetransdk.OpType_DELETE, operationRecord.Record.Type)
+	data := operationRecord.Record.Data
+	assert.NotNil(t, data)
+	assert.Equal(t, 2, len(data), "should serialize only primary keys for deleted rows")
+	assert.Equal(t, int32(123), data["customer_id"].GetShort())
+	assert.Equal(t, "string:\"PhaniRaj\"", data["name"].String())
 }
 
 func generateTestRecord() (*sqltypes.Result, *fivetransdk.Schema, error) {
@@ -229,12 +272,14 @@ func generateTestRecord() (*sqltypes.Result, *fivetransdk.Schema, error) {
 				Name: "Customers",
 				Columns: []*fivetransdk.Column{
 					{
-						Name: "customer_id",
-						Type: fivetransdk.DataType_SHORT,
+						Name:       "customer_id",
+						Type:       fivetransdk.DataType_SHORT,
+						PrimaryKey: true,
 					},
 					{
-						Name: "name",
-						Type: fivetransdk.DataType_STRING,
+						Name:       "name",
+						Type:       fivetransdk.DataType_STRING,
+						PrimaryKey: true,
 					},
 					{
 						Name: "first_name",
@@ -367,7 +412,7 @@ func TestCanSkipColumns(t *testing.T) {
 		},
 	}
 
-	err := l.Record(row, schema, table)
+	err := l.Record(row, schema, table, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, tl.lastResponse)
 
@@ -406,7 +451,7 @@ func BenchmarkRecordSerialization_Serializer(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n++ {
-		err := l.Record(row, schema, table)
+		err := l.Record(row, schema, table, 0)
 		if err != nil {
 			b.Fatalf("failed with %v", err.Error())
 		}

--- a/cmd/internal/server/handlers/sync_test.go
+++ b/cmd/internal/server/handlers/sync_test.go
@@ -37,7 +37,9 @@ func TestCallsReadWithSelectedSchema(t *testing.T) {
 		},
 	}
 
-	readFn := func(ctx context.Context, logger lib.DatabaseLogger, ps lib.PlanetScaleSource, tableName string, columns []string, tc *psdbconnect.TableCursor, onResult lib.OnResult, onCursor lib.OnCursor) (*lib.SerializedCursor, error) {
+	readFn := func(ctx context.Context, logger lib.DatabaseLogger, ps lib.PlanetScaleSource, tableName string, columns []string,
+		tc *psdbconnect.TableCursor, onResult lib.OnResult, onCursor lib.OnCursor, onUpdate lib.OnUpdate,
+	) (*lib.SerializedCursor, error) {
 		assert.Equal(t, "customers", tableName)
 		return nil, nil
 	}

--- a/cmd/internal/server/handlers/test_types.go
+++ b/cmd/internal/server/handlers/test_types.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"fmt"
+
 	fivetransdk "github.com/planetscale/fivetran-proto/go"
 	"github.com/planetscale/fivetran-source/lib"
 	"vitess.io/vitess/go/sqltypes"
@@ -28,7 +30,11 @@ func (testLogger) Log(level fivetransdk.LogLevel, s string) error {
 	panic("implement me")
 }
 
-func (testLogger) Record(result *sqltypes.Result, selection *fivetransdk.SchemaSelection, selection2 *fivetransdk.TableSelection) error {
+func (testLogger) Update(*lib.UpdatedRow, *fivetransdk.SchemaSelection, *fivetransdk.TableSelection) error {
+	return fmt.Errorf("%v is not implemented", "Update")
+}
+
+func (testLogger) Record(result *sqltypes.Result, selection *fivetransdk.SchemaSelection, selection2 *fivetransdk.TableSelection, operation lib.Operation) error {
 	// TODO implement me
 	panic("implement me")
 }

--- a/cmd/internal/server/server.go
+++ b/cmd/internal/server/server.go
@@ -167,7 +167,6 @@ func (c *connectorServer) Update(request *fivetran_sdk.UpdateRequest, server fiv
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	fmt.Println("Getting source schema now")
 	sourceSchema, err := c.schema.Handle(ctx, psc, &mysqlClient)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "unable get source schema for this database : %q", err)

--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -392,7 +392,7 @@ func TestUpdateReturnsDeletes(t *testing.T) {
 func TestUpdateReturnsUpdates(t *testing.T) {
 	ctx := context.Background()
 	beforeIntValue := strconv.AppendInt(nil, int64(int8(12)), 10)
-	beforeResult, mysqlClientConstructor := setupUpdateRowsTest(beforeIntValue)
+	beforeResult, _ := setupUpdateRowsTest(beforeIntValue)
 	afterIntValue := strconv.AppendInt(nil, int64(int8(17)), 10)
 	afterResult, mysqlClientConstructor := setupUpdateRowsTest(afterIntValue)
 

--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -156,119 +156,10 @@ func TestUpdateValidatesState(t *testing.T) {
 	assert.ErrorContains(t, err, "request did not contain a valid stateJson")
 }
 
-func TestUpdateReturnsRows(t *testing.T) {
+func TestUpdateReturnsInserts(t *testing.T) {
 	ctx := context.Background()
 	intValue := strconv.AppendInt(nil, int64(int8(12)), 10)
-	allTypesResult := &sqltypes.Result{
-		Fields: []*querypb.Field{
-			{Name: "Type_INT8", Type: querypb.Type_INT8},
-			{Name: "Type_UINT8", Type: querypb.Type_UINT8},
-			{Name: "Type_INT16", Type: querypb.Type_INT16},
-			{Name: "Type_UINT16", Type: querypb.Type_UINT16},
-			{Name: "Type_INT24", Type: querypb.Type_INT24},
-			{Name: "Type_UINT24", Type: querypb.Type_UINT24},
-			{Name: "Type_INT32", Type: querypb.Type_INT32},
-			{Name: "Type_UINT32", Type: querypb.Type_UINT32},
-			{Name: "Type_INT64", Type: querypb.Type_INT64},
-			{Name: "Type_UINT64", Type: querypb.Type_UINT64},
-			{Name: "Type_FLOAT32", Type: querypb.Type_FLOAT32},
-			{Name: "Type_FLOAT64", Type: querypb.Type_FLOAT64},
-			{Name: "Type_TIMESTAMP", Type: querypb.Type_TIMESTAMP},
-			{Name: "Type_DATE", Type: querypb.Type_DATE},
-			{Name: "Type_TIME", Type: querypb.Type_TIME},
-			{Name: "Type_DATETIME", Type: querypb.Type_DATETIME},
-			{Name: "Type_YEAR", Type: querypb.Type_YEAR},
-			{Name: "Type_DECIMAL", Type: querypb.Type_DECIMAL},
-			{Name: "Type_TEXT", Type: querypb.Type_TEXT},
-			{Name: "Type_BLOB", Type: querypb.Type_BLOB},
-			{Name: "Type_VARCHAR", Type: querypb.Type_VARCHAR},
-			{Name: "Type_VARBINARY", Type: querypb.Type_VARBINARY},
-			{Name: "Type_CHAR", Type: querypb.Type_CHAR},
-			{Name: "Type_BINARY", Type: querypb.Type_BINARY},
-			{Name: "Type_BIT", Type: querypb.Type_BIT},
-			{Name: "Type_ENUM", Type: querypb.Type_ENUM},
-			{Name: "Type_SET", Type: querypb.Type_SET},
-			// Skip TUPLE, not possible in Result.
-			{Name: "Type_GEOMETRY", Type: querypb.Type_GEOMETRY},
-			{Name: "Type_JSON", Type: querypb.Type_JSON},
-		},
-		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.MakeTrusted(querypb.Type_INT8, intValue),
-				sqltypes.MakeTrusted(querypb.Type_UINT8, intValue),
-				sqltypes.MakeTrusted(querypb.Type_INT16, intValue),
-				sqltypes.MakeTrusted(querypb.Type_UINT16, intValue),
-				sqltypes.MakeTrusted(querypb.Type_INT24, intValue),
-				sqltypes.MakeTrusted(querypb.Type_UINT24, intValue),
-				sqltypes.MakeTrusted(querypb.Type_INT32, intValue),
-				sqltypes.MakeTrusted(querypb.Type_UINT32, intValue),
-				sqltypes.MakeTrusted(querypb.Type_INT64, intValue),
-				sqltypes.MakeTrusted(querypb.Type_UINT64, intValue),
-				sqltypes.MakeTrusted(querypb.Type_FLOAT32, []byte("1.00")),
-				sqltypes.MakeTrusted(querypb.Type_FLOAT64, []byte("1.00")),
-				sqltypes.MakeTrusted(querypb.Type_TIMESTAMP, []byte("2006-01-02 15:04:05")),
-				sqltypes.MakeTrusted(querypb.Type_DATE, []byte("2023-03-24")),
-				sqltypes.MakeTrusted(querypb.Type_TIME, []byte("Type_TIME")),
-				sqltypes.MakeTrusted(querypb.Type_DATETIME, []byte("2023-03-23 14:28:21.592111")),
-				sqltypes.MakeTrusted(querypb.Type_YEAR, []byte("2023")),
-				sqltypes.MakeTrusted(querypb.Type_DECIMAL, []byte("Type_DECIMAL")),
-				sqltypes.MakeTrusted(querypb.Type_TEXT, []byte("Type_TEXT")),
-				sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("Type_BLOB")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("Type_VARCHAR")),
-				sqltypes.MakeTrusted(querypb.Type_VARBINARY, []byte("Type_VARBINARY")),
-				sqltypes.MakeTrusted(querypb.Type_CHAR, []byte("Type_CHAR")),
-				sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("Type_BINARY")),
-				sqltypes.MakeTrusted(querypb.Type_BIT, []byte{1}),
-				sqltypes.MakeTrusted(querypb.Type_ENUM, []byte("3")),
-				sqltypes.MakeTrusted(querypb.Type_SET, []byte{0x01, 0x02}),
-				sqltypes.MakeTrusted(querypb.Type_GEOMETRY, []byte("Type_GEOMETRY")),
-				sqltypes.MakeTrusted(querypb.Type_JSON, []byte("Type_JSON")),
-			},
-		},
-	}
-
-	mysqlClientConstructor := func() lib.MysqlClient {
-		return &lib.TestMysqlClient{
-			BuildSchemaFn: func(ctx context.Context, psc lib.PlanetScaleSource, schemaBuilder lib.SchemaBuilder) error {
-				schemaBuilder.OnKeyspace("SalesDB")
-				schemaBuilder.OnTable("SalesDB", "customers")
-				schemaBuilder.OnColumns("SalesDB", "customers",
-					[]lib.MysqlColumn{
-						{Name: "Type_INT8", Type: "int"},
-						{Name: "Type_UINT8", Type: "smallint"},
-						{Name: "Type_INT16", Type: "smallint"},
-						{Name: "Type_UINT16", Type: "int"},
-						{Name: "Type_INT24", Type: "int"},
-						{Name: "Type_UINT24", Type: "int"},
-						{Name: "Type_INT32", Type: "int"},
-						{Name: "Type_UINT32", Type: "unsigned int"},
-						{Name: "Type_INT64", Type: "bigint"},
-						{Name: "Type_UINT64", Type: "unsigned bigint"},
-						{Name: "Type_FLOAT32", Type: "float"},
-						{Name: "Type_FLOAT64", Type: "double"},
-						{Name: "Type_TIMESTAMP", Type: "timestamp"},
-						{Name: "Type_DATE", Type: "date"},
-						{Name: "Type_TIME", Type: "time"},
-						{Name: "Type_DATETIME", Type: "datetime"},
-						{Name: "Type_YEAR", Type: "year"},
-						{Name: "Type_DECIMAL", Type: "decimal"},
-						{Name: "Type_TEXT", Type: "varchar"},
-						{Name: "Type_BLOB", Type: "blob"},
-						{Name: "Type_VARCHAR", Type: "varchar"},
-						{Name: "Type_VARBINARY", Type: "geometry"},
-						{Name: "Type_CHAR", Type: "char"},
-						{Name: "Type_BINARY", Type: "binary"},
-						{Name: "Type_BIT", Type: "bit"},
-						{Name: "Type_ENUM", Type: "enum"},
-						{Name: "Type_SET", Type: "set"},
-						// Skip TUPLE, not possible in Result.
-						{Name: "Type_GEOMETRY", Type: "geometry"},
-						{Name: "Type_JSON", Type: "json"},
-					})
-				return nil
-			},
-		}
-	}
+	allTypesResult, mysqlClientConstructor := setupUpdateRowsTest(intValue)
 
 	clientConstructor := func() lib.ConnectClient {
 		return &lib.TestConnectClient{
@@ -349,6 +240,7 @@ func TestUpdateReturnsRows(t *testing.T) {
 	assert.Equal(t, "SalesDB", *record.Record.SchemaName)
 	assert.Equal(t, "customers", record.Record.TableName)
 
+	assert.Equal(t, record.Record.Type, fivetransdk.OpType_UPSERT)
 	for _, field := range allTypesResult.Fields {
 		assert.NotEmpty(t, record.Record.Data[field.Name].Inner, "expected value for %q field", field.Name)
 		assert.NotNil(t, record.Record.Data[field.Name].Inner, "expected value for %q field", field.Name)
@@ -363,7 +255,6 @@ func TestUpdateReturnsRows(t *testing.T) {
 		Keyspaces: map[string]lib.KeyspaceState{},
 	}
 
-	fmt.Printf("checkpoint is %s", checkpoint.Checkpoint.StateJson)
 	err = json.Unmarshal([]byte(checkpoint.Checkpoint.StateJson), &syncState)
 	require.NoError(t, err)
 
@@ -378,6 +269,234 @@ func TestUpdateReturnsRows(t *testing.T) {
 	customShard, ok := customers.Shards["-40"]
 	assert.True(t, ok)
 	assert.Equal(t, "CgMtNDASB1NhbGVzREI=", customShard.Cursor)
+}
+
+func TestUpdateReturnsDeletes(t *testing.T) {
+	ctx := context.Background()
+	intValue := strconv.AppendInt(nil, int64(int8(12)), 10)
+	allTypesResult, mysqlClientConstructor := setupUpdateRowsTest(intValue)
+
+	clientConstructor := func() lib.ConnectClient {
+		return &lib.TestConnectClient{
+			ListShardsFn: func(ctx context.Context, ps lib.PlanetScaleSource) ([]string, error) {
+				return []string{"-", "-40"}, nil
+			},
+			CanConnectFn: func(ctx context.Context, ps lib.PlanetScaleSource) error {
+				return nil
+			},
+			ReadFn: func(ctx context.Context, logger lib.DatabaseLogger, ps lib.PlanetScaleSource, tableName string, columns []string, tc *psdbconnect.TableCursor, onResult lib.OnResult, onCursor lib.OnCursor) (*lib.SerializedCursor, error) {
+				assert.Equal(t, "customers", tableName)
+				assert.NotNil(t, columns)
+				onResult(allTypesResult, lib.OpType_Delete)
+				return nil, nil
+			},
+		}
+	}
+	client, closer := server(ctx, clientConstructor, mysqlClientConstructor)
+	defer closer()
+	customerSelection := &fivetransdk.TableSelection{
+		Included:  true,
+		TableName: "customers",
+		Columns:   map[string]bool{},
+	}
+
+	for _, f := range allTypesResult.Fields {
+		customerSelection.Columns[f.Name] = true
+	}
+
+	selection := &fivetransdk.Selection_WithSchema{
+		WithSchema: &fivetransdk.TablesWithSchema{
+			Schemas: []*fivetransdk.SchemaSelection{
+				{
+					SchemaName: "SalesDB",
+					Included:   true,
+					Tables: []*fivetransdk.TableSelection{
+						customerSelection,
+						{
+							Included:  false,
+							TableName: "customer_secrets",
+						},
+					},
+				},
+			},
+		},
+	}
+	out, err := client.Update(ctx, &fivetransdk.UpdateRequest{
+		Configuration: map[string]string{
+			"host":     "earth.psdb",
+			"username": "phanatic",
+			"password": "password",
+			"database": "employees",
+		},
+		Selection: &fivetransdk.Selection{
+			Selection: selection,
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+
+	rows := make([]*fivetransdk.UpdateResponse, 0, 3)
+	for {
+		resp, err := out.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed test with %q", err)
+		}
+		rows = append(rows, resp)
+	}
+	assert.Len(t, rows, 3)
+	operation := rows[0].GetOperation()
+	assert.NotNil(t, operation)
+	record, ok := operation.Op.(*fivetransdk.Operation_Record)
+	assert.True(t, ok)
+	assert.NotNil(t, record)
+	assert.Equal(t, "SalesDB", *record.Record.SchemaName)
+	assert.Equal(t, "customers", record.Record.TableName)
+
+	assert.Equal(t, record.Record.Type, fivetransdk.OpType_DELETE)
+	assert.Equal(t, 1, len(record.Record.Data))
+
+	assert.Equal(t, &fivetransdk.ValueType_Int{Int: 12}, record.Record.Data["Type_INT8"].Inner)
+
+	operation = rows[len(rows)-1].GetOperation()
+	checkpoint, ok := operation.Op.(*fivetransdk.Operation_Checkpoint)
+	assert.True(t, ok)
+	assert.NotNil(t, checkpoint)
+
+	syncState := lib.SyncState{
+		Keyspaces: map[string]lib.KeyspaceState{},
+	}
+
+	err = json.Unmarshal([]byte(checkpoint.Checkpoint.StateJson), &syncState)
+	require.NoError(t, err)
+
+	ks, ok := syncState.Keyspaces["SalesDB"]
+	assert.True(t, ok)
+	customers, ok := ks.Streams["SalesDB:customers"]
+	assert.True(t, ok)
+	defaultShard, ok := customers.Shards["-"]
+	assert.True(t, ok)
+	assert.Equal(t, "CgEtEgdTYWxlc0RC", defaultShard.Cursor)
+
+	customShard, ok := customers.Shards["-40"]
+	assert.True(t, ok)
+	assert.Equal(t, "CgMtNDASB1NhbGVzREI=", customShard.Cursor)
+}
+
+func setupUpdateRowsTest(intValue []byte) (*sqltypes.Result, func() lib.MysqlClient) {
+	allTypesResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Name: "Type_INT8", Type: querypb.Type_INT8},
+			{Name: "Type_UINT8", Type: querypb.Type_UINT8},
+			{Name: "Type_INT16", Type: querypb.Type_INT16},
+			{Name: "Type_UINT16", Type: querypb.Type_UINT16},
+			{Name: "Type_INT24", Type: querypb.Type_INT24},
+			{Name: "Type_UINT24", Type: querypb.Type_UINT24},
+			{Name: "Type_INT32", Type: querypb.Type_INT32},
+			{Name: "Type_UINT32", Type: querypb.Type_UINT32},
+			{Name: "Type_INT64", Type: querypb.Type_INT64},
+			{Name: "Type_UINT64", Type: querypb.Type_UINT64},
+			{Name: "Type_FLOAT32", Type: querypb.Type_FLOAT32},
+			{Name: "Type_FLOAT64", Type: querypb.Type_FLOAT64},
+			{Name: "Type_TIMESTAMP", Type: querypb.Type_TIMESTAMP},
+			{Name: "Type_DATE", Type: querypb.Type_DATE},
+			{Name: "Type_TIME", Type: querypb.Type_TIME},
+			{Name: "Type_DATETIME", Type: querypb.Type_DATETIME},
+			{Name: "Type_YEAR", Type: querypb.Type_YEAR},
+			{Name: "Type_DECIMAL", Type: querypb.Type_DECIMAL},
+			{Name: "Type_TEXT", Type: querypb.Type_TEXT},
+			{Name: "Type_BLOB", Type: querypb.Type_BLOB},
+			{Name: "Type_VARCHAR", Type: querypb.Type_VARCHAR},
+			{Name: "Type_VARBINARY", Type: querypb.Type_VARBINARY},
+			{Name: "Type_CHAR", Type: querypb.Type_CHAR},
+			{Name: "Type_BINARY", Type: querypb.Type_BINARY},
+			{Name: "Type_BIT", Type: querypb.Type_BIT},
+			{Name: "Type_ENUM", Type: querypb.Type_ENUM},
+			{Name: "Type_SET", Type: querypb.Type_SET},
+			// Skip TUPLE, not possible in Result.
+			{Name: "Type_GEOMETRY", Type: querypb.Type_GEOMETRY},
+			{Name: "Type_JSON", Type: querypb.Type_JSON},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT8, intValue),
+				sqltypes.MakeTrusted(querypb.Type_UINT8, intValue),
+				sqltypes.MakeTrusted(querypb.Type_INT16, intValue),
+				sqltypes.MakeTrusted(querypb.Type_UINT16, intValue),
+				sqltypes.MakeTrusted(querypb.Type_INT24, intValue),
+				sqltypes.MakeTrusted(querypb.Type_UINT24, intValue),
+				sqltypes.MakeTrusted(querypb.Type_INT32, intValue),
+				sqltypes.MakeTrusted(querypb.Type_UINT32, intValue),
+				sqltypes.MakeTrusted(querypb.Type_INT64, intValue),
+				sqltypes.MakeTrusted(querypb.Type_UINT64, intValue),
+				sqltypes.MakeTrusted(querypb.Type_FLOAT32, []byte("1.00")),
+				sqltypes.MakeTrusted(querypb.Type_FLOAT64, []byte("1.00")),
+				sqltypes.MakeTrusted(querypb.Type_TIMESTAMP, []byte("2006-01-02 15:04:05")),
+				sqltypes.MakeTrusted(querypb.Type_DATE, []byte("2023-03-24")),
+				sqltypes.MakeTrusted(querypb.Type_TIME, []byte("Type_TIME")),
+				sqltypes.MakeTrusted(querypb.Type_DATETIME, []byte("2023-03-23 14:28:21.592111")),
+				sqltypes.MakeTrusted(querypb.Type_YEAR, []byte("2023")),
+				sqltypes.MakeTrusted(querypb.Type_DECIMAL, []byte("Type_DECIMAL")),
+				sqltypes.MakeTrusted(querypb.Type_TEXT, []byte("Type_TEXT")),
+				sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("Type_BLOB")),
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("Type_VARCHAR")),
+				sqltypes.MakeTrusted(querypb.Type_VARBINARY, []byte("Type_VARBINARY")),
+				sqltypes.MakeTrusted(querypb.Type_CHAR, []byte("Type_CHAR")),
+				sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("Type_BINARY")),
+				sqltypes.MakeTrusted(querypb.Type_BIT, []byte{1}),
+				sqltypes.MakeTrusted(querypb.Type_ENUM, []byte("3")),
+				sqltypes.MakeTrusted(querypb.Type_SET, []byte{0x01, 0x02}),
+				sqltypes.MakeTrusted(querypb.Type_GEOMETRY, []byte("Type_GEOMETRY")),
+				sqltypes.MakeTrusted(querypb.Type_JSON, []byte("Type_JSON")),
+			},
+		},
+	}
+
+	mysqlClientConstructor := func() lib.MysqlClient {
+		return &lib.TestMysqlClient{
+			BuildSchemaFn: func(ctx context.Context, psc lib.PlanetScaleSource, schemaBuilder lib.SchemaBuilder) error {
+				schemaBuilder.OnKeyspace("SalesDB")
+				schemaBuilder.OnTable("SalesDB", "customers")
+				schemaBuilder.OnColumns("SalesDB", "customers",
+					[]lib.MysqlColumn{
+						{Name: "Type_INT8", Type: "int", IsPrimaryKey: true},
+						{Name: "Type_UINT8", Type: "smallint"},
+						{Name: "Type_INT16", Type: "smallint"},
+						{Name: "Type_UINT16", Type: "int"},
+						{Name: "Type_INT24", Type: "int"},
+						{Name: "Type_UINT24", Type: "int"},
+						{Name: "Type_INT32", Type: "int"},
+						{Name: "Type_UINT32", Type: "unsigned int"},
+						{Name: "Type_INT64", Type: "bigint"},
+						{Name: "Type_UINT64", Type: "unsigned bigint"},
+						{Name: "Type_FLOAT32", Type: "float"},
+						{Name: "Type_FLOAT64", Type: "double"},
+						{Name: "Type_TIMESTAMP", Type: "timestamp"},
+						{Name: "Type_DATE", Type: "date"},
+						{Name: "Type_TIME", Type: "time"},
+						{Name: "Type_DATETIME", Type: "datetime"},
+						{Name: "Type_YEAR", Type: "year"},
+						{Name: "Type_DECIMAL", Type: "decimal"},
+						{Name: "Type_TEXT", Type: "varchar"},
+						{Name: "Type_BLOB", Type: "blob"},
+						{Name: "Type_VARCHAR", Type: "varchar"},
+						{Name: "Type_VARBINARY", Type: "geometry"},
+						{Name: "Type_CHAR", Type: "char"},
+						{Name: "Type_BINARY", Type: "binary"},
+						{Name: "Type_BIT", Type: "bit"},
+						{Name: "Type_ENUM", Type: "enum"},
+						{Name: "Type_SET", Type: "set"},
+						// Skip TUPLE, not possible in Result.
+						{Name: "Type_GEOMETRY", Type: "geometry"},
+						{Name: "Type_JSON", Type: "json"},
+					})
+				return nil
+			},
+		}
+	}
+	return allTypesResult, mysqlClientConstructor
 }
 
 func TestUpdateReturnsState(t *testing.T) {

--- a/lib/test_types.go
+++ b/lib/test_types.go
@@ -88,7 +88,7 @@ func (t TestMysqlClient) Close() error {
 }
 
 type (
-	ReadFunc       func(ctx context.Context, logger DatabaseLogger, ps PlanetScaleSource, tableName string, columns []string, tc *psdbconnect.TableCursor, onResult OnResult, onCursor OnCursor) (*SerializedCursor, error)
+	ReadFunc       func(ctx context.Context, logger DatabaseLogger, ps PlanetScaleSource, tableName string, columns []string, tc *psdbconnect.TableCursor, onResult OnResult, onCursor OnCursor, onUpdate OnUpdate) (*SerializedCursor, error)
 	CanConnectFunc func(ctx context.Context, ps PlanetScaleSource) error
 	ListShardsFunc func(ctx context.Context, ps PlanetScaleSource) ([]string, error)
 
@@ -116,7 +116,7 @@ func (tcc *TestConnectClient) CanConnect(ctx context.Context, ps PlanetScaleSour
 
 func (tcc *TestConnectClient) Read(ctx context.Context, logger DatabaseLogger, ps PlanetScaleSource, tableName string, columns []string, lastKnownPosition *psdbconnect.TableCursor, onResult OnResult, onCursor OnCursor, onUpdate OnUpdate) (*SerializedCursor, error) {
 	if tcc.ReadFn != nil {
-		return tcc.ReadFn(ctx, logger, ps, tableName, columns, lastKnownPosition, onResult, onCursor)
+		return tcc.ReadFn(ctx, logger, ps, tableName, columns, lastKnownPosition, onResult, onCursor, onUpdate)
 	}
 
 	return nil, errors.New("Read is Unimplemented")


### PR DESCRIPTION
Depends on https://github.com/planetscale/fivetran-source/pull/15 

This PR implements sending UpdateResponses to Fivetran with an operation type of `Optype_Delete` to fivetran.
Deleted rows are sent to fivetran with only values for the primary keys.  I've added some tests to the serializer as well as the server to ensure that we have end-to-end coverage.

1. Deletes : Only send Primary Keys of the deleted rows.
2. Updates : Send Primary keys + any changed columns of the updated rows