### PR TITLE
Fix bug with duplicate tables in Schema output

### DIFF
--- a/cmd/internal/server/handlers/schema_builder.go
+++ b/cmd/internal/server/handlers/schema_builder.go
@@ -57,6 +57,7 @@ func (s *fivetranSchemaBuilder) getOrCreateTable(keyspaceName string, tableName 
 			Name:    tableName,
 			Columns: []*fivetransdk.Column{},
 		}
+		schema.Tables = append(schema.Tables, table)
 	}
 
 	if s.tables == nil {
@@ -67,7 +68,6 @@ func (s *fivetranSchemaBuilder) getOrCreateTable(keyspaceName string, tableName 
 		s.tables[keyspaceName] = map[string]*fivetransdk.Table{}
 	}
 
-	schema.Tables = append(schema.Tables, table)
 	s.tables[keyspaceName][tableName] = table
 	return table
 }


### PR DESCRIPTION
Found this while testing with Fivetran's mockFivetran utility.