### PR TITLE
Convert tinyint(1) to boolean values if selected.

### DIFF
--- a/cmd/internal/server/handlers/schema_builder.go
+++ b/cmd/internal/server/handlers/schema_builder.go
@@ -113,7 +113,7 @@ func (s *fivetranSchemaBuilder) BuildResponse() (*fivetransdk.SchemaResponse, er
 func getFivetranDataType(mType string, treatTinyIntAsBoolean bool) (fivetransdk.DataType, *fivetransdk.DecimalParams) {
 	mysqlType := strings.ToLower(mType)
 	if strings.HasPrefix(mysqlType, "tinyint") {
-		if treatTinyIntAsBoolean {
+		if treatTinyIntAsBoolean && mysqlType == "tinyint(1)" {
 			return fivetransdk.DataType_BOOLEAN, nil
 		}
 

--- a/cmd/internal/server/handlers/schema_builder_test.go
+++ b/cmd/internal/server/handlers/schema_builder_test.go
@@ -67,6 +67,16 @@ func TestSchema_CanPickRightFivetranType(t *testing.T) {
 			TreatTinyIntAsBoolean: false,
 		},
 		{
+			MysqlType:             "tinyint unsigned",
+			FivetranType:          fivetransdk.DataType_INT,
+			TreatTinyIntAsBoolean: true,
+		},
+		{
+			MysqlType:             "tinyint",
+			FivetranType:          fivetransdk.DataType_INT,
+			TreatTinyIntAsBoolean: true,
+		},
+		{
 			MysqlType:             "timestamp",
 			FivetranType:          fivetransdk.DataType_UTC_DATETIME,
 			TreatTinyIntAsBoolean: true,


### PR DESCRIPTION
We were making all types that were prefixed with `tinyint` as boolean if `treat tinyint as boolean` was selected. 
We should instead be looking for the exact term `tinyint(1)` and turn them into booleans.