### PR TITLE
Encode Spatial values as GeoJson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build-server:
 
 .PHONY: server
 server:
-	@go run ./cmd/server/main.go
+	@go run ./cmd/server/main.go -port 50051
 
 .PHONY: lint
 lint:

--- a/cmd/internal/server/handlers/fivetran_value_converters.go
+++ b/cmd/internal/server/handlers/fivetran_value_converters.go
@@ -178,8 +178,8 @@ var converters = map[fivetransdk.DataType]ConverterFunc{
 			// we use this function to get the hex representation of the base-10 WKB
 			hexValues := fmt.Sprintf("%x", b)
 			buf := new(bytes.Buffer)
-			// skip the first 8 characters because they're padding
-			// as vitess uses 4 bytes to store the WKB of geometry types.
+			// Skip the first 8 characters because they're padding
+			// as mysql uses 4 bytes to store the WKB of geometry types.
 			// Since WKB in mysql only uses 25 chracters, where the 1st character
 			// determines Endianness, and is used by vitess when we call `ToBytes` above.
 			buf.Write([]byte(hexValues[8:]))

--- a/cmd/internal/server/handlers/fivetran_value_converters.go
+++ b/cmd/internal/server/handlers/fivetran_value_converters.go
@@ -1,15 +1,20 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"time"
 
+	"github.com/spatial-go/geoos/geoencoding"
+	"github.com/spatial-go/geoos/geoencoding/geojson"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+
 	"github.com/pkg/errors"
 	fivetransdk "github.com/planetscale/fivetran-sdk-grpc/go"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"vitess.io/vitess/go/sqltypes"
 )
 
@@ -158,6 +163,43 @@ var converters = map[fivetransdk.DataType]ConverterFunc{
 		}, nil
 	},
 	fivetransdk.DataType_JSON: func(value sqltypes.Value) (*fivetransdk.ValueType, error) {
+		if value.Type() == querypb.Type_GEOMETRY {
+			// we tell Fivetran that all geoemtry types are in fact serialized as JSON values.
+			// which is why we need to depend on the value type here to inform us to serialize
+			// geometry values as GeoJson
+			// 1. Get the Well Known Binary representation of the geometry value here.
+			// Docs: https://dev.mysql.com/doc/refman/8.0/en/gis-data-formats.html#gis-wkb-format
+			b, err := value.ToBytes()
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to get bytes for Geometry type")
+			}
+
+			// vitess's value types return the WKB as an array of bytes in base 10
+			// we use this function to get the hex representation of the base-10 WKB
+			hexValues := fmt.Sprintf("%x", b)
+			buf := new(bytes.Buffer)
+			// skip the first 8 characters because they're padding
+			// as vitess uses 4 bytes to store the WKB of geometry types.
+			// Since WKB in mysql only uses 25 chracters, where the 1st character
+			// determines Endianness, and is used by vitess when we call `ToBytes` above.
+			buf.Write([]byte(hexValues[8:]))
+			got, err := geoencoding.Read(buf, geoencoding.WKB)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to serialize Geometry type")
+			}
+			if got == nil {
+				return nil, fmt.Errorf("invalid Geometry value: %s", b)
+			}
+
+			// serialize the geometric shape as GeoJson
+			// GeoJson examples are available in the RFC here :
+			// https://datatracker.ietf.org/doc/html/rfc7946#section-1.5
+			gj := geojson.GeojsonEncoder{}
+			geoJson := gj.Encode(got.Geom())
+			return &fivetransdk.ValueType{
+				Inner: &fivetransdk.ValueType_Json{Json: string(geoJson)},
+			}, nil
+		}
 		return &fivetransdk.ValueType{
 			Inner: &fivetransdk.ValueType_Json{Json: value.ToString()},
 		}, nil

--- a/cmd/internal/server/handlers/schema.go
+++ b/cmd/internal/server/handlers/schema.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/planetscale/fivetran-source/lib"
 
@@ -16,7 +15,5 @@ func (Schema) Handle(ctx context.Context, psc *lib.PlanetScaleSource, db *lib.My
 	if err := (*db).BuildSchema(ctx, *psc, schemaBuilder); err != nil {
 		return nil, err
 	}
-	r, _ := schemaBuilder.(*fivetranSchemaBuilder).BuildResponse()
-	fmt.Printf("\n\t tables are:  %v ", r.Response.(*fivetransdk.SchemaResponse_WithSchema).WithSchema.Schemas[0].Tables)
-	return r, nil
+	return schemaBuilder.(*fivetranSchemaBuilder).BuildResponse()
 }

--- a/cmd/internal/server/handlers/schema.go
+++ b/cmd/internal/server/handlers/schema.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/planetscale/fivetran-source/lib"
 
@@ -15,6 +16,7 @@ func (Schema) Handle(ctx context.Context, psc *lib.PlanetScaleSource, db *lib.My
 	if err := (*db).BuildSchema(ctx, *psc, schemaBuilder); err != nil {
 		return nil, err
 	}
-
-	return schemaBuilder.(*fivetranSchemaBuilder).BuildResponse()
+	r, _ := schemaBuilder.(*fivetranSchemaBuilder).BuildResponse()
+	fmt.Printf("\n\t tables are:  %v ", r.Response.(*fivetransdk.SchemaResponse_WithSchema).WithSchema.Schemas[0].Tables)
+	return r, nil
 }

--- a/cmd/internal/server/handlers/sync.go
+++ b/cmd/internal/server/handlers/sync.go
@@ -56,7 +56,7 @@ func (s *Sync) Handle(psc *lib.PlanetScaleSource, db *lib.ConnectClient, logger 
 				columns := includedColumns(table)
 				sc, err := (*db).Read(ctx, logger, *psc, table.TableName, columns, tc, onRow, onCursor, onUpdate)
 				if err != nil {
-					return status.Error(codes.Internal, fmt.Sprintf("failed to download rows for table : %s", table.TableName))
+					return status.Error(codes.Internal, fmt.Sprintf("failed to download rows for table : %s , error : %s", table.TableName, err.Error()))
 				}
 				if sc != nil {
 					// if we get any new state, we assign it here.

--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -161,7 +161,6 @@ func TestUpdateValidatesState(t *testing.T) {
 }
 
 func TestCanSerializeGeometryTypes(t *testing.T) {
-
 	tests := []struct {
 		Type string
 		Hex  string
@@ -215,14 +214,14 @@ func TestCanSerializeGeometryTypes(t *testing.T) {
 		t.Run(fmt.Sprintf("geometry_type_%v", geoTest.Type), func(t *testing.T) {
 			geometry, err := hex.DecodeString(geoTest.Hex)
 			if err != nil {
-				panic(err)
+				t.Fatalf("failed to encode geometry value with %q", err)
 			}
-			geometryTypeTest(t, geometry, geoTest.Json, err)
+			geometryTypeTest(t, geometry, geoTest.Json)
 		})
 	}
 }
 
-func geometryTypeTest(t *testing.T, geometry []byte, geojson string, err error) {
+func geometryTypeTest(t *testing.T, geometry []byte, geojson string) {
 	geometryTypeResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "Type_GEOMETRY", Type: querypb.Type_GEOMETRY},

--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -219,7 +219,7 @@ func TestUpdateReturnsInserts(t *testing.T) {
 			Selection: selection,
 		},
 	})
-	assert.NoError(t, err)
+	require.Error(t, err)
 	assert.NotNil(t, out)
 
 	rows := make([]*fivetransdk.UpdateResponse, 0, 3)
@@ -234,8 +234,10 @@ func TestUpdateReturnsInserts(t *testing.T) {
 		rows = append(rows, resp)
 	}
 	assert.Len(t, rows, 3)
+	fmt.Printf("\n\t log entry is %s", rows[0].GetLogEntry())
 	operation := rows[0].GetOperation()
 	assert.NotNil(t, operation)
+	fmt.Printf("\n\tOperation is %s\n", operation)
 	record, ok := operation.Op.(*fivetransdk.Operation_Record)
 	assert.True(t, ok)
 	assert.NotNil(t, record)

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,147 +1,147 @@
 ---
 - - :permit
   - New BSD
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-13 20:38:40.936333000 Z
 - - :permit
   - Apache 2.0
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-13 20:38:48.800174000 Z
 - - :approve
   - github.com/pkg/errors
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-13 22:13:54.921723000 Z
 - - :approve
   - github.com/planetscale/psdb
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-13 22:13:57.825477000 Z
 - - :approve
   - github.com/DataDog/sketches-go,
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:34.732400000 Z
 - - :approve
   - github.com/DataDog/datadog-go/v5
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:36.455827000 Z
 - - :approve
   - github.com/DataDog/sketches-go,
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:36.976212000 Z
 - - :approve
   - github.com/beorn7/perks
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:37.499850000 Z
 - - :approve
   - github.com/cespare/xxhash/v2
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:38.023569000 Z
 - - :approve
   - github.com/dustin/go-humanize
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:38.547779000 Z
 - - :approve
   - github.com/go-sql-driver/mysql
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:39.072593000 Z
 - - :approve
   - github.com/philhofer/fwd
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:39.591419000 Z
 - - :approve
   - github.com/segmentio/asm
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:40.123877000 Z
 - - :approve
   - github.com/tinylib/msgp
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:40.650766000 Z
 - - :approve
   - go.uber.org/atomic
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:41.197585000 Z
 - - :approve
   - github.com/DataDog/datadog-go/v5
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:55.443067000 Z
 - - :approve
   - github.com/DataDog/sketches-go,
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:55.964941000 Z
 - - :approve
   - github.com/beorn7/perks
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:56.489102000 Z
 - - :approve
   - github.com/cespare/xxhash/v2
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:57.006746000 Z
 - - :approve
   - github.com/dustin/go-humanize
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:57.532722000 Z
 - - :approve
   - github.com/go-sql-driver/mysql
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:58.050855000 Z
 - - :approve
   - github.com/philhofer/fwd
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:58.564699000 Z
 - - :approve
   - github.com/segmentio/asm
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:59.102804000 Z
 - - :approve
   - github.com/DataDog/datadog-go
   - &1
-    :who:
-    :why:
+    :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:38:59.638198000 Z
 - - :approve
@@ -149,14 +149,14 @@
   - *1
 - - :approve
   - go.uber.org/atomic
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-02-14 16:39:00.167589000 Z
 - - :approve
   - github.com/planetscale/fivetran-proto
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-03-28 22:17:08.505235000 Z
 - - :approve
@@ -169,3 +169,9 @@
 - - :approve
   - Thai
   - *2
+- - :approve
+  - github.com/spatial-go/geoos
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2023-08-08 15:14:05.040229000 Z

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/planetscale/airbyte-source v1.16.0
 	github.com/planetscale/fivetran-sdk-grpc v0.0.0-20230726214605-855c05dcd065
 	github.com/planetscale/psdb v0.0.0-20220429000526-e2a0e798aaf3
+	github.com/spatial-go/geoos v1.1.3
 	github.com/stretchr/testify v1.8.2
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
@@ -36,7 +37,6 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
-	github.com/planetscale/fivetran-sdk-grpc v0.0.0-20230726214605-855c05dcd065 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -665,6 +665,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
+github.com/spatial-go/geoos v1.1.3 h1:POhtMdlGxbsAOqSNMkYuDvZ9woAHJlf5iVZBlayAw/I=
+github.com/spatial-go/geoos v1.1.3/go.mod h1:ast/LDHx7Vl1buou2h+AYlmZL+ZD/45OcEg5R52xY8o=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=


### PR DESCRIPTION
This PR supports serializing Mysql Spatial values as GeoJson.
In the past, we'd try to send the Well Known Binary format of the geometry value as the `string` property of a JSON object to Fivetran. However, it won't work since this wouldn't produce valid utf-8 text as the `string` property.

Instead, we will : 
1. Convert the base-10 representation of the WKB from vitess to Hex
2. Read the WKB into a Geometry object
3. Serialize the geometry object as GeoJson
### Sample MockFiveTran output 

WKB as represented by Mysql 

``` sql
select ST_AsText(location), location from address LIMIT 1;
+--------------------------------+------------------------------------------------------+
| ST_AsText(location)            | location                                             |
+--------------------------------+------------------------------------------------------+
| POINT(-112.8185647 49.6999986) | 0x0000000001010000003E0A325D63345CC0761FDB8D99D94840 |
+--------------------------------+------------------------------------------------------+
```

Value as serialized by PlanetScale's fivetran source and picked up by the MockFivetran utility.

``` bash
Aug 08, 2023 3:00:39 PM com.fivetran.fivetran_sdk.tools.MockConnectorOutput handleUpsert
INFO: [Upsert]: test-1.address  Data: {postal_code=string: "27107"
, location=json: "{\"type\":\"Point\",\"coordinates\":[128.0449753,46.9804391]} "
, address2=string: ""
, address=string: "1325 Fukuyama Street"
, district=string: "Heilongjiang"
, city_id=int: 537
, address_id=int: 605
, phone=string: "288241215394"
, last_update=utc_datetime {
  seconds: 1411684244
}
}
```

* Mysql Spatial Types : https://dev.mysql.com/doc/refman/8.0/en/gis-data-formats.html
* GeoJson RFC : https://datatracker.ietf.org/doc/html/rfc7946#section-1.5
