### PR TITLE
Support Null values in all fields

### DIFF
--- a/cmd/internal/server/handlers/fivetran_value_converters.go
+++ b/cmd/internal/server/handlers/fivetran_value_converters.go
@@ -122,7 +122,7 @@ var converters = map[fivetransdk.DataType]ConverterFunc{
 		// The DATE type is used for values with a date part but no time part.
 		// MySQL retrieves and displays DATE values in 'YYYY-MM-DD' format.
 		// The supported range is '1000-01-01' to '9999-12-31'.
-		t, err := time.Parse("2006-01-02", value.ToString())
+		t, err := time.Parse(time.DateOnly, value.ToString())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to serialize DataType_NAIVE_DATE")
 		}
@@ -134,7 +134,8 @@ var converters = map[fivetransdk.DataType]ConverterFunc{
 		// The DATETIME type is used for values that contain both date and time parts.
 		// MySQL retrieves and displays DATETIME values in 'YYYY-MM-DD hh:mm:ss' format.
 		// The supported range is '1000-01-01 00:00:00' to '9999-12-31 23:59:59'.
-		t, err := time.Parse("2006-01-02 15:04:05", value.ToString())
+
+		t, err := time.Parse(time.DateTime, value.ToString())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to serialize DataType_NAIVE_DATETIME")
 		}

--- a/cmd/internal/server/handlers/schema_aware_serializer.go
+++ b/cmd/internal/server/handlers/schema_aware_serializer.go
@@ -102,10 +102,19 @@ func (s *schemaAwareRecordSerializer) Serialize(before *sqltypes.Result, after *
 			if !writeColumn {
 				continue
 			}
-
-			fVal, err := writer(val)
-			if err != nil {
-				return nil, errors.Wrap(err, "unable to serialize row")
+			var (
+				fVal *fivetransdk.ValueType
+				err  error
+			)
+			if val.IsNull() {
+				fVal = &fivetransdk.ValueType{
+					Inner: &fivetransdk.ValueType_Null{Null: true},
+				}
+			} else {
+				fVal, err = writer(val)
+				if err != nil {
+					return nil, errors.Wrap(err, "unable to serialize row")
+				}
 			}
 			record[colName] = fVal
 		}


### PR DESCRIPTION
This PR fixes an issue with us failing to serialize Null values for all fields of a record.
