### PR TITLE
Allow schema retrieval to take more than 2 seconds

### DIFF
--- a/cmd/internal/server/server.go
+++ b/cmd/internal/server/server.go
@@ -3,9 +3,10 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/planetscale/fivetran-source/cmd/internal/server/handlers"
 	"log"
 	"os"
+
+	"github.com/planetscale/fivetran-source/cmd/internal/server/handlers"
 
 	"github.com/planetscale/fivetran-source/lib"
 

--- a/cmd/internal/server/server.go
+++ b/cmd/internal/server/server.go
@@ -3,11 +3,9 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/planetscale/fivetran-source/cmd/internal/server/handlers"
 	"log"
 	"os"
-	"time"
-
-	"github.com/planetscale/fivetran-source/cmd/internal/server/handlers"
 
 	"github.com/planetscale/fivetran-source/lib"
 
@@ -164,17 +162,14 @@ func (c *connectorServer) Update(request *fivetran_sdk.UpdateRequest, server fiv
 		db = c.clientConstructor()
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	sourceSchema, err := c.schema.Handle(ctx, psc, &mysqlClient)
+	sourceSchema, err := c.schema.Handle(context.Background(), psc, &mysqlClient)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "unable get source schema for this database : %q", err)
 	}
 
 	logger := handlers.NewSchemaAwareSerializer(server, requestId, psc.TreatTinyIntAsBoolean, sourceSchema.GetWithSchema())
 
-	shards, err := db.ListShards(ctx, *psc)
+	shards, err := db.ListShards(context.Background(), *psc)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "unable to list shards for this database : %q", err)
 	}


### PR DESCRIPTION
We're seeing errors in production where databases with larger schemas fail their `Update` call. 

``` json
{
  "event" : "sync_end",
  "data" : {
    "status" : "FAILURE",
    "reason" : "INVALID_ARGUMENT: unable get source schema for this database : \"Unable to build schema for database: Unable to get column names & types for table integration_database_branch_collection: context deadline exceeded\""
  },
  "created" : "2023-08-30T21:32:56.699Z",
  "connector_type" : "planetscale",
  "connector_id" : "beet_assimilate",
  "connector_name" : "psdb_test",
  "sync_id" : "f808d146-d02e-4677-a2cc-279a402bf4e5",
  "exception_id" : "bda46209-dcc1-44c5-8403-ed4e59a97e7a"
}
```

This PR removes the arbitrary 2 second timeout and allows fivetran user to cancel the sync session instead of timing out the request in the connector.