### PR TITLE
Fix field title and allow streaming from replica

### DIFF
--- a/cmd/internal/server/handlers/configuration_form.go
+++ b/cmd/internal/server/handlers/configuration_form.go
@@ -56,9 +56,20 @@ func (ConfigurationForm) Handle(ctx context.Context, _ *fivetransdk.Configuratio
 			},
 			{
 				Name:  "shards",
-				Label: "(Optional) Comma-separated list of shards to sync",
+				Label: "Comma-separated list of shards to sync",
 				Type: &fivetransdk.FormField_TextField{
 					TextField: fivetransdk.TextField_PlainText,
+				},
+			},
+			{
+				Name:  "use_replica",
+				Label: "Use Replica?",
+				Type: &fivetransdk.FormField_DropdownField{
+					DropdownField: &fivetransdk.DropdownField{
+						DropdownField: []string{
+							"true", "false",
+						},
+					},
 				},
 			},
 			{

--- a/cmd/internal/server/types.go
+++ b/cmd/internal/server/types.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
@@ -82,6 +83,22 @@ func SourceFromRequest(request ConfiguredRequest) (*lib.PlanetScaleSource, error
 		psc.Host = val
 	} else {
 		return nil, errors.New("hostname not found in configuration")
+	}
+
+	if val, ok := configuration["treat_tiny_int_as_boolean"]; ok {
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, errors.New("treat_tiny_int_as_boolean is not a boolean")
+		}
+		psc.TreatTinyIntAsBoolean = b
+	}
+
+	if val, ok := configuration["use_replica"]; ok {
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, errors.New("use_replica is not a boolean")
+		}
+		psc.UseReplica = b
 	}
 
 	return psc, nil

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/airbyte-source v1.16.0
+	github.com/planetscale/airbyte-source v1.18.0
 	github.com/planetscale/fivetran-sdk-grpc v0.0.0-20230808175316-83fcd813d46b
 	github.com/planetscale/psdb v0.0.0-20220429000526-e2a0e798aaf3
 	github.com/spatial-go/geoos v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -600,10 +600,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
-github.com/planetscale/airbyte-source v1.16.0 h1:edgR8Vr99XQmCNaInHaAL+xN1a0+d3DjeEBerSUfQv8=
-github.com/planetscale/airbyte-source v1.16.0/go.mod h1:I4jdxCyHAJ/XmJCF7hQOZM2mvUK5FM7hKkUya5IVFDc=
-github.com/planetscale/fivetran-sdk-grpc v0.0.0-20230726214605-855c05dcd065 h1:JVG4BXVpCJ3thOOfwC8rjpYXwURczxTTjfWDmcnncv0=
-github.com/planetscale/fivetran-sdk-grpc v0.0.0-20230726214605-855c05dcd065/go.mod h1:HE+UELC4d/tqQ5yBJ8LRFuTEwrvzMEBBAppsgvvQ6l0=
+github.com/planetscale/airbyte-source v1.18.0 h1:gNBKaEjO9bhSCqhRn4EAPx9NEkhZPo8ZXIricdbDDNo=
+github.com/planetscale/airbyte-source v1.18.0/go.mod h1:I4jdxCyHAJ/XmJCF7hQOZM2mvUK5FM7hKkUya5IVFDc=
 github.com/planetscale/fivetran-sdk-grpc v0.0.0-20230808175316-83fcd813d46b h1:q+6tGWhoKeLKP32HMiGkNEhp63SQQsPGrOoPSi4HvlU=
 github.com/planetscale/fivetran-sdk-grpc v0.0.0-20230808175316-83fcd813d46b/go.mod h1:HE+UELC4d/tqQ5yBJ8LRFuTEwrvzMEBBAppsgvvQ6l0=
 github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a h1:y0OpQ4+5tKxeh9+H+2cVgASl9yMZYV9CILinKOiKafA=

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -326,6 +326,7 @@ func (p connectClient) getLatestCursorPosition(ctx context.Context, shard, keysp
 			Position: "current",
 		},
 		TabletType: tabletType,
+		Cells:      []string{"planetscale_operator_default"},
 	}
 
 	c, err := client.Sync(ctx, sReq)

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -105,6 +105,10 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 	)
 
 	tabletType := psdbconnect.TabletType_primary
+	if ps.UseReplica {
+		tabletType = psdbconnect.TabletType_replica
+	}
+
 	currentPosition := lastKnownPosition
 	readDuration := 1 * time.Minute
 	preamble := fmt.Sprintf("[%v:%v shard : %v] ", ps.Database, tableName, currentPosition.Shard)
@@ -195,6 +199,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 		IncludeUpdates: true,
 		IncludeInserts: true,
 		IncludeDeletes: true,
+		Cells:          []string{"planetscale_operator_default"},
 	}
 
 	c, err := client.Sync(ctx, sReq)

--- a/lib/planetscale_source.go
+++ b/lib/planetscale_source.go
@@ -18,6 +18,7 @@ type PlanetScaleSource struct {
 	Password              string `json:"password"`
 	Shards                string `json:"shards"`
 	TreatTinyIntAsBoolean bool   `json:"treat_tiny_int_as_boolean"`
+	UseReplica            bool   `json:"use_replica"`
 }
 
 // DSN returns a DataSource that mysql libraries can use to connect to a PlanetScale database.


### PR DESCRIPTION
This PR makes two changes: 
1. Remove the word "optional" from the field title so that the UI doesn't render duplicate "optional" in the title. 
2. Allow the fivetran connector to stream from a replica. 