### PR TITLE
Send a TRUNCATE operation on first sync of a table

### DIFF
--- a/cmd/internal/server/handlers/sync.go
+++ b/cmd/internal/server/handlers/sync.go
@@ -26,7 +26,6 @@ func (s *Sync) Handle(psc *lib.PlanetScaleSource, db *lib.ConnectClient, logger 
 	ctx := context.Background()
 	for _, ks := range includedKeyspaces(schema) {
 		for _, table := range includedTables(ks) {
-
 			stateKey := ks.SchemaName + ":" + table.TableName
 			streamState, ok := state.Keyspaces[ks.SchemaName].Streams[stateKey]
 			if !ok {
@@ -53,6 +52,11 @@ func (s *Sync) Handle(psc *lib.PlanetScaleSource, db *lib.ConnectClient, logger 
 				if err != nil {
 					return status.Error(codes.Internal, fmt.Sprintf("invalid cursor for stream %v, failed with [%v]", stateKey, err))
 				}
+
+				if tc.Position == "" {
+					logger.Truncate(ks, table)
+				}
+
 				columns := includedColumns(table)
 				sc, err := (*db).Read(ctx, logger, *psc, table.TableName, columns, tc, onRow, onCursor, onUpdate)
 				if err != nil {

--- a/cmd/internal/server/handlers/sync_test.go
+++ b/cmd/internal/server/handlers/sync_test.go
@@ -44,15 +44,63 @@ func TestCallsReadWithSelectedSchema(t *testing.T) {
 		return nil, nil
 	}
 
+	state, err := psc.GetInitialState("SalesDB", []string{"-"})
+	assert.NoError(t, err)
 	db := lib.NewTestConnectClient(readFn)
-	err := sync.Handle(psc, &db, tl, &lib.SyncState{
+	err = sync.Handle(psc, &db, tl, &lib.SyncState{
 		Keyspaces: map[string]lib.KeyspaceState{
 			"SalesDB": {
 				Streams: map[string]lib.ShardStates{
-					"SalesDB:customers": {},
+					"SalesDB:customers": state,
 				},
 			},
 		},
 	}, schemaSelection)
 	assert.NoError(t, err)
+}
+
+func TestCallsTruncateOnInitialSync(t *testing.T) {
+	psc := &lib.PlanetScaleSource{}
+	tl := &testLogger{}
+	schema := fivetransdk.SchemaSelection{
+		SchemaName: "SalesDB",
+		Included:   true,
+		Tables: []*fivetransdk.TableSelection{
+			{
+				Included:  true,
+				TableName: "customers",
+			},
+		},
+	}
+	sync := Sync{}
+	schemaSelection := &fivetransdk.Selection_WithSchema{
+		WithSchema: &fivetransdk.TablesWithSchema{
+			Schemas: []*fivetransdk.SchemaSelection{
+				&schema,
+			},
+		},
+	}
+
+	readFn := func(ctx context.Context, logger lib.DatabaseLogger, ps lib.PlanetScaleSource, tableName string, columns []string,
+		tc *psdbconnect.TableCursor, onResult lib.OnResult, onCursor lib.OnCursor, onUpdate lib.OnUpdate,
+	) (*lib.SerializedCursor, error) {
+		assert.Equal(t, "customers", tableName)
+		return nil, nil
+	}
+
+	state, err := psc.GetInitialState("SalesDB", []string{"-"})
+	assert.NoError(t, err)
+
+	db := lib.NewTestConnectClient(readFn)
+	err = sync.Handle(psc, &db, tl, &lib.SyncState{
+		Keyspaces: map[string]lib.KeyspaceState{
+			"SalesDB": {
+				Streams: map[string]lib.ShardStates{
+					"SalesDB:customers": state,
+				},
+			},
+		},
+	}, schemaSelection)
+	assert.NoError(t, err)
+	assert.True(t, tl.truncateCalled)
 }

--- a/cmd/internal/server/handlers/test_types.go
+++ b/cmd/internal/server/handlers/test_types.go
@@ -18,32 +18,39 @@ func (l *testLogSender) Send(response *fivetransdk.UpdateResponse) error {
 	return l.sendError
 }
 
-type testLogger struct{}
+type testLogger struct {
+	truncateCalled bool
+}
 
 func (testLogger) Info(s string) {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (testLogger) Log(level fivetransdk.LogLevel, s string) error {
+func (tl *testLogger) Log(level fivetransdk.LogLevel, s string) error {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (testLogger) Update(*lib.UpdatedRow, *fivetransdk.SchemaSelection, *fivetransdk.TableSelection) error {
+func (tl *testLogger) Update(*lib.UpdatedRow, *fivetransdk.SchemaSelection, *fivetransdk.TableSelection) error {
 	return fmt.Errorf("%v is not implemented", "Update")
 }
 
-func (testLogger) Record(result *sqltypes.Result, selection *fivetransdk.SchemaSelection, selection2 *fivetransdk.TableSelection, operation lib.Operation) error {
+func (tl *testLogger) Truncate(*fivetransdk.SchemaSelection, *fivetransdk.TableSelection) error {
+	tl.truncateCalled = true
+	return nil
+}
+
+func (tl *testLogger) Record(result *sqltypes.Result, selection *fivetransdk.SchemaSelection, selection2 *fivetransdk.TableSelection, operation lib.Operation) error {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (testLogger) State(state lib.SyncState) error {
+func (tl *testLogger) State(state lib.SyncState) error {
 	return nil
 }
 
-func (testLogger) Release() {
+func (tl *testLogger) Release() {
 	// TODO implement me
 	panic("implement me")
 }

--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -311,8 +311,8 @@ func geometryTypeTest(t *testing.T, geometry []byte, geojson string) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 3)
-	operation := rows[0].GetOperation()
+	assert.Len(t, rows, 5)
+	operation := rows[1].GetOperation()
 	require.NotNil(t, operation)
 	record, ok := operation.Op.(*fivetransdk.Operation_Record)
 	assert.True(t, ok)
@@ -409,8 +409,8 @@ func TestUpdateReturnsInserts(t *testing.T) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 3)
-	operation := rows[0].GetOperation()
+	assert.Len(t, rows, 5)
+	operation := rows[1].GetOperation()
 	require.NotNil(t, operation)
 	record, ok := operation.Op.(*fivetransdk.Operation_Record)
 	assert.True(t, ok)
@@ -528,7 +528,7 @@ func TestUpdateReturnsErrors(t *testing.T) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 0)
+	assert.Len(t, rows, 1)
 	assert.NotNil(t, tErr)
 	assert.Equal(t, "rpc error: code = Internal desc = failed to download rows for table : customers , error : unable to serialize: DataType.BIG_INT", tErr.Error())
 }
@@ -610,8 +610,8 @@ func TestUpdateReturnsDeletes(t *testing.T) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 3)
-	operation := rows[0].GetOperation()
+	assert.Len(t, rows, 5)
+	operation := rows[1].GetOperation()
 	assert.NotNil(t, operation)
 	record, ok := operation.Op.(*fivetransdk.Operation_Record)
 	assert.True(t, ok)
@@ -729,8 +729,8 @@ func TestUpdateReturnsUpdates(t *testing.T) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 3)
-	operation := rows[0].GetOperation()
+	assert.Len(t, rows, 5)
+	operation := rows[1].GetOperation()
 	assert.NotNil(t, operation)
 	record, ok := operation.Op.(*fivetransdk.Operation_Record)
 	assert.True(t, ok)
@@ -971,8 +971,8 @@ func TestUpdateReturnsState(t *testing.T) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 2)
-	operation := rows[0].GetOperation()
+	assert.Len(t, rows, 3)
+	operation := rows[1].GetOperation()
 	assert.NotNil(t, operation)
 	checkpoint, ok := operation.Op.(*fivetransdk.Operation_Checkpoint)
 	require.True(t, ok)

--- a/lib/types.go
+++ b/lib/types.go
@@ -16,6 +16,7 @@ const (
 	OpType_Insert Operation = iota
 	OpType_Update
 	OpType_Delete
+	OpType_Truncate
 )
 
 type UpdatedRow struct {


### PR DESCRIPTION
This PR makes a change to the Fivetran connector to send a record with OpType of `TRUNCATE` on first sync of a table. 
This is to allow Fivetran to mark any existing rows of the table with the _fivetan_deleted column if any data existed at the destination already. 
This is useful in scenarios where a customer wants to resync the entire table from scratch on an existing connection. 
