### PR TITLE
Fix casing for Fivetran name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq ($(OS),Darwin)
 	PROTOC_PLATFORM := osx
 endif
 FIVETRANSDK_PROTO_OUT := fivetran_sdk
-FIVETRAN_PROTO_VERSION := 8b110ac32f1859336ef46727537e32a07ac974bd
+FIVETRAN_PROTO_VERSION := d3af8f0cec22214e4b130af1b794f080602bfa38
 
 .PHONY: all
 all: build test lint-fmt lint

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # fivetran-source
-PlanetScale Source connector for FiveTran
+PlanetScale Source connector for Fivetran
 
 
 ## Testing locally

--- a/cmd/internal/server/types.go
+++ b/cmd/internal/server/types.go
@@ -104,7 +104,7 @@ func SourceFromRequest(request ConfiguredRequest) (*lib.PlanetScaleSource, error
 	return psc, nil
 }
 
-// StateFromRequest unmarshals the stateJson saved in FiveTran
+// StateFromRequest unmarshals the stateJson saved in Fivetran
 // and turns that into a structure we can use within the connector to
 // incrementally sync tables from PlanetScale.
 func StateFromRequest(request StatefulRequest, source lib.PlanetScaleSource, shards []string, schemaSelection fivetransdk.Selection_WithSchema) (*lib.SyncState, error) {

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -163,7 +163,7 @@
   - github.com/planetscale/fivetran-sdk-grpc
   - &2
     :who: Frances
-    :why: PlanetScale's private fork of new FiveTran protos
+    :why: PlanetScale's private fork of new Fivetran protos
     :versions: []
     :when: 2023-07-27 19:42:15.786151000 Z
 - - :approve

--- a/lib/mysql_client.go
+++ b/lib/mysql_client.go
@@ -37,7 +37,7 @@ type mysqlClient struct {
 // 1. Get all keyspaces for the PlanetScale database
 // 2. Get the schemas for all tables in a keyspace, for each keyspace
 // 2. Get columns and primary keys for each table from information_schema.columns
-// 3. Format results into FiveTran response
+// 3. Format results into Fivetran response
 func (p mysqlClient) BuildSchema(ctx context.Context, psc PlanetScaleSource, schemaBuilder SchemaBuilder) error {
 	keyspaces, err := p.GetKeyspaces(ctx, psc)
 	if err != nil {

--- a/lib/planetscale_source.go
+++ b/lib/planetscale_source.go
@@ -9,7 +9,7 @@ import (
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 )
 
-// PlanetScaleSource defines a configured FiveTran Source for a PlanetScale database
+// PlanetScaleSource defines a configured Fivetran Source for a PlanetScale database
 // Consider this a connection string to a PlanetScale database.
 type PlanetScaleSource struct {
 	Host                  string `json:"host"`
@@ -60,7 +60,7 @@ func useSecureConnection() bool {
 }
 
 // GetInitialState will return the initial/blank state for a given keyspace in all of its shards.
-// This state can be round-tripped safely with FiveTran.
+// This state can be round-tripped safely with Fivetran.
 func (psc PlanetScaleSource) GetInitialState(keyspaceOrDatabase string, shards []string) (ShardStates, error) {
 	shardCursors := ShardStates{
 		Shards: map[string]*SerializedCursor{},


### PR DESCRIPTION
Supersedes https://github.com/planetscale/fivetran-source/pull/39 from before the repo history purge for proto files.