### PR TITLE
Remove check for hostname

### DIFF
--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -1007,26 +1007,6 @@ func TestCheckConnectionReturnsSuccess(t *testing.T) {
 	assert.True(t, success.Success, "response should be a success status")
 }
 
-func TestCheckConnectionReturnsErrorIfNotEdgePassword(t *testing.T) {
-	ctx := context.Background()
-	client, closer := server(ctx, nil, nil)
-	defer closer()
-	resp, err := client.Test(ctx, &fivetransdk.TestRequest{
-		Name: handlers.CheckConnectionTestName,
-		Configuration: map[string]string{
-			"host":     "earth.psdb",
-			"username": "phanatic",
-			"password": "password",
-			"database": "employees",
-		},
-	})
-
-	assert.NoError(t, err)
-	fail, ok := resp.Response.(*fivetransdk.TestResponse_Failure)
-	assert.True(t, ok, "response should be a TestResponse_Failure")
-	assert.Equal(t, fail.Failure, "Unable to initialize Connect Session: This password is not connect-enabled, please ensure that your organization is enrolled in the Connect beta.")
-}
-
 func TestCheckConnectionReturnsErrorIfCheckFails(t *testing.T) {
 	ctx := context.Background()
 	clientConstructor := func() lib.ConnectClient {

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"vitess.io/vitess/go/vt/proto/query"
@@ -73,9 +72,6 @@ func (p connectClient) CanConnect(ctx context.Context, ps PlanetScaleSource) err
 }
 
 func (p connectClient) checkEdgePassword(ctx context.Context, psc PlanetScaleSource) error {
-	if !strings.HasSuffix(psc.Host, ".connect.psdb.cloud") {
-		return errors.New("This password is not connect-enabled, please ensure that your organization is enrolled in the Connect beta.")
-	}
 	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("https://%v", psc.Host), nil)


### PR DESCRIPTION
The hostname check isn't necessary anymore since we don't issue credentials to the old mysql gateway.