### PR TITLE
Add ability to tail a specific table in test client

### DIFF
--- a/testclients/grpcclient/main.go
+++ b/testclients/grpcclient/main.go
@@ -112,12 +112,9 @@ func tailTable() {
 		}
 
 		if operation, ok := res.Response.(*fivetran_sdk.UpdateResponse_Operation); ok {
-			//operation.Operation.Op
 			if rec, ok := operation.Operation.Op.(*fivetran_sdk.Operation_Record); ok {
-
 				fmt.Printf("[Record] : %v\n", rec.Record)
 			}
-
 		}
 	}
 }

--- a/testclients/grpcclient/main.go
+++ b/testclients/grpcclient/main.go
@@ -13,19 +13,111 @@ import (
 )
 
 var addr = flag.String("addr", "localhost:50051", "the address to connect to")
+var tableName = flag.String("table", "", "table to download")
+var schemaName = flag.String("schema", "", "schema for table to download")
+
+// fill in connection values
+var configuration = map[string]string{
+	"username": "",
+	"password": "",
+	"host":     "",
+	"database": "",
+}
 
 func main() {
 	flag.Parse()
+	tailTable()
+}
+
+func getTableSchema(tableName string, configuration map[string]string) (*fivetran_sdk.TableSelection, error) {
 	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
 	defer conn.Close()
 	cc := fivetran_sdk.NewConnectorClient(conn)
-	resp, err := cc.ConfigurationForm(context.Background(), &fivetran_sdk.ConfigurationFormRequest{}, grpc.UseCompressor(gzip.Name))
+	resp, err := cc.Schema(context.Background(), &fivetran_sdk.SchemaRequest{Configuration: configuration})
+	if err != nil {
+		return nil, err
+	}
+
+	schemaList := resp.Response.(*fivetran_sdk.SchemaResponse_WithSchema).WithSchema
+	for _, schema := range schemaList.Schemas {
+		for _, table := range schema.Tables {
+			if table.Name == tableName {
+				ts := &fivetran_sdk.TableSelection{
+					TableName: tableName,
+					Included:  true,
+					Columns:   make(map[string]bool),
+				}
+
+				for _, column := range table.Columns {
+					ts.Columns[column.Name] = true
+				}
+
+				return ts, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func tailTable() {
+	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+	cc := fivetran_sdk.NewConnectorClient(conn)
+	maxMsgSize := 16777216
+
+	ts, err := getTableSchema(*tableName, configuration)
+	if err != nil {
+		log.Fatalf("Failed getting table schema with %v", err)
+	}
+
+	resp, err := cc.Update(context.Background(), &fivetran_sdk.UpdateRequest{
+		Configuration: configuration,
+		Selection: &fivetran_sdk.Selection{
+			Selection: &fivetran_sdk.Selection_WithSchema{
+				WithSchema: &fivetran_sdk.TablesWithSchema{
+					Schemas: []*fivetran_sdk.SchemaSelection{
+						&fivetran_sdk.SchemaSelection{
+							Included:   true,
+							SchemaName: *schemaName,
+							Tables: []*fivetran_sdk.TableSelection{
+								ts,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+		grpc.UseCompressor(gzip.Name),
+		grpc.MaxCallRecvMsgSize(maxMsgSize))
 	if err != nil {
 		log.Fatalf("Failed with %v", err)
 	}
 
-	fmt.Printf("\\n\t receieved response : %v", resp)
+	for {
+		res, err := resp.Recv()
+		if err != nil {
+			log.Fatalf("Failed with %v", err)
+		}
+
+		if log, ok := res.Response.(*fivetran_sdk.UpdateResponse_LogEntry); ok {
+			fmt.Println(log.LogEntry.Message)
+		}
+
+		if operation, ok := res.Response.(*fivetran_sdk.UpdateResponse_Operation); ok {
+			//operation.Operation.Op
+			if rec, ok := operation.Operation.Op.(*fivetran_sdk.Operation_Record); ok {
+
+				fmt.Printf("[Record] : %v\n", rec.Record)
+			}
+
+		}
+	}
 }

--- a/testclients/grpcclient/main.go
+++ b/testclients/grpcclient/main.go
@@ -12,9 +12,11 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 )
 
-var addr = flag.String("addr", "localhost:50051", "the address to connect to")
-var tableName = flag.String("table", "", "table to download")
-var schemaName = flag.String("schema", "", "schema for table to download")
+var (
+	addr       = flag.String("addr", "localhost:50051", "the address to connect to")
+	tableName  = flag.String("table", "", "table to download")
+	schemaName = flag.String("schema", "", "schema for table to download")
+)
 
 // fill in connection values
 var configuration = map[string]string{
@@ -83,7 +85,7 @@ func tailTable() {
 			Selection: &fivetran_sdk.Selection_WithSchema{
 				WithSchema: &fivetran_sdk.TablesWithSchema{
 					Schemas: []*fivetran_sdk.SchemaSelection{
-						&fivetran_sdk.SchemaSelection{
+						{
 							Included:   true,
 							SchemaName: *schemaName,
 							Tables: []*fivetran_sdk.TableSelection{


### PR DESCRIPTION
This PR modifies the test grpcclient to `tail` a specific table and download all rows within it via the grpc interface. 
I used this to debug why compression didn't work and to find the offending row that was over 16 MB in size. 

It sends a Schema request first to grab the table schema and sends an Update request while selecting all columns within the table. 

### Example run
``` bash
go run main.go --table departments --schema new-import-test
[Record] : schema_name:"new-import-test"  table_name:"departments"  type:TRUNCATE
request-02809baf-244d-4297-aafe-4113d37151ce [new-import-test:departments shard : -] peeking to see if there's any new rows
request-02809baf-244d-4297-aafe-4113d37151ce new rows found, syncing rows for 1m0s
request-02809baf-244d-4297-aafe-4113d37151ce [new-import-test:departments shard : -] syncing rows with cursor [shard:"-" keyspace:"new-import-test"]
request-02809baf-244d-4297-aafe-4113d37151ce Syncing with cursor position : [], using last known PK : false, stop cursor is : [MySQL56/001c845d-c1e4-11ee-8225-52331b887298:1-54,170479c5-b631-11ee-803f-c241d807d5a0:1-782,170684d5-b631-11ee-9606-76e44633283e:1-1913,279038a2-c49c-11ee-bfc1-b6c09c22790a:1-2481,279473f4-c49c-11ee-ba45-722d6a3d80cb:1-49,3d117837-ab37-11ee-8c9a-5635b3841f14:1-18402,3d52b54c-ab37-11ee-b139-a22d9c6f796f:1-7091,6ab5ad91-d283-11ee-9ddb-92e04b213c02:1-307]
request-02809baf-244d-4297-aafe-4113d37151ce using enum converter for column size and values [x-small small medium large x-large]
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Marketing"}}  data:{key:"dept_no"  value:{string:"d001"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Finance"}}  data:{key:"dept_no"  value:{string:"d002"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Human Resources"}}  data:{key:"dept_no"  value:{string:"d003"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Production"}}  data:{key:"dept_no"  value:{string:"d004"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Development"}}  data:{key:"dept_no"  value:{string:"d005"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Quality Management"}}  data:{key:"dept_no"  value:{string:"d006"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Sales"}}  data:{key:"dept_no"  value:{string:"d007"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Research"}}  data:{key:"dept_no"  value:{string:"d008"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Customer Service"}}  data:{key:"dept_no"  value:{string:"d009"}}  data:{key:"size"  value:{string:"small"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Edited this row to see what's up"}}  data:{key:"dept_no"  value:{string:"d011"}}  data:{key:"size"  value:{string:"x-large"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"Last PK Event With Fields"}}  data:{key:"dept_no"  value:{string:"d012"}}  data:{key:"size"  value:{string:"x-large"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"copy phase"}}  data:{key:"dept_no"  value:{string:"d014"}}  data:{key:"size"  value:{string:"x-large"}}
[Record] : schema_name:"new-import-test"  table_name:"departments"  data:{key:"dept_name"  value:{string:"updated gtids"}}  data:{key:"dept_no"  value:{string:"d019"}}  data:{key:"size"  value:{null:true}}
request-02809baf-244d-4297-aafe-4113d37151ce [new-import-test:departments shard : -] Finished reading all rows for table [departments]
2024/02/27 15:34:56 Failed with EOF
```