### PR TITLE
Add option to pass in starting GTID

### DIFF
--- a/cmd/internal/server/handlers/configuration_form.go
+++ b/cmd/internal/server/handlers/configuration_form.go
@@ -86,6 +86,14 @@ func (ConfigurationForm) Handle(ctx context.Context, _ *fivetransdk.Configuratio
 					},
 				},
 			},
+			{
+				Name:        "starting_gtids",
+				Label:       "JSON containing keyspace, shard, and starting GTIDs",
+				Description: &tinyIntDesc,
+				Type: &fivetransdk.FormField_TextField{
+					TextField: fivetransdk.TextField_PlainText,
+				},
+			},
 		},
 		Tests: []*fivetransdk.ConfigurationTest{
 			{

--- a/cmd/internal/server/handlers/sync_test.go
+++ b/cmd/internal/server/handlers/sync_test.go
@@ -104,3 +104,71 @@ func TestCallsTruncateOnInitialSync(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, tl.truncateCalled)
 }
+
+func TestCallsReadWithStartingGtids(t *testing.T) {
+	psc := &lib.PlanetScaleSource{
+		StartingGtids: "{\"SalesDB\":{\"-80\":\"MySQL56/MYGTID:1-3\",\"80-\":\"MySQL56/MYOTHERGTID:1-3\"}}",
+	}
+
+	tl := &testLogger{}
+	schema := fivetransdk.SchemaSelection{
+		SchemaName: "SalesDB",
+		Included:   true,
+		Tables: []*fivetransdk.TableSelection{
+			{
+				Included:  true,
+				TableName: "customers",
+			},
+			{
+				Included:  false,
+				TableName: "customer_secrets",
+			},
+		},
+	}
+	sync := Sync{}
+	schemaSelection := &fivetransdk.Selection_WithSchema{
+		WithSchema: &fivetransdk.TablesWithSchema{
+			Schemas: []*fivetransdk.SchemaSelection{
+				&schema,
+			},
+		},
+	}
+
+	readFn := func(ctx context.Context, logger lib.DatabaseLogger, ps lib.PlanetScaleSource, tableName string, columns []string,
+		tc *psdbconnect.TableCursor, onResult lib.OnResult, onCursor lib.OnCursor, onUpdate lib.OnUpdate,
+	) (*lib.SerializedCursor, error) {
+		assert.Equal(t, "customers", tableName)
+		return nil, nil
+	}
+
+	state, err := psc.GetInitialState("SalesDB", []string{"-80", "80-"})
+	assert.NoError(t, err)
+
+	cursor, err := lib.TableCursorToSerializedCursor(&psdbconnect.TableCursor{
+		Shard:    "-80",
+		Keyspace: "SalesDB",
+		Position: "MySQL56/MYGTID:1-3",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, state.Shards["-80"], cursor)
+
+	cursor, err = lib.TableCursorToSerializedCursor(&psdbconnect.TableCursor{
+		Shard:    "80-",
+		Keyspace: "SalesDB",
+		Position: "MySQL56/MYOTHERGTID:1-3",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, state.Shards["80-"], cursor)
+
+	db := lib.NewTestConnectClient(readFn)
+	err = sync.Handle(psc, &db, tl, &lib.SyncState{
+		Keyspaces: map[string]lib.KeyspaceState{
+			"SalesDB": {
+				Streams: map[string]lib.ShardStates{
+					"SalesDB:customers": state,
+				},
+			},
+		},
+	}, schemaSelection)
+	assert.NoError(t, err)
+}

--- a/cmd/internal/server/server.go
+++ b/cmd/internal/server/server.go
@@ -181,7 +181,7 @@ func (c *connectorServer) Update(request *fivetran_sdk.UpdateRequest, server fiv
 		return status.Errorf(codes.InvalidArgument, "unable to list shards for this database : %q", err)
 	}
 	var state *lib.SyncState
-	state, err = StateFromRequest(request, *psc, shards, *schemaSelection)
+	state, err = StateFromRequest(logger, request, *psc, shards, *schemaSelection)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, fmt.Sprintf("request did not contain a valid stateJson : %q", err))
 	}

--- a/cmd/internal/server/types.go
+++ b/cmd/internal/server/types.go
@@ -101,13 +101,17 @@ func SourceFromRequest(request ConfiguredRequest) (*lib.PlanetScaleSource, error
 		psc.UseReplica = b
 	}
 
+	if val, ok := configuration["starting_gtids"]; ok {
+		psc.StartingGtids = val
+	}
+
 	return psc, nil
 }
 
 // StateFromRequest unmarshals the stateJson saved in Fivetran
 // and turns that into a structure we can use within the connector to
 // incrementally sync tables from PlanetScale.
-func StateFromRequest(request StatefulRequest, source lib.PlanetScaleSource, shards []string, schemaSelection fivetransdk.Selection_WithSchema) (*lib.SyncState, error) {
+func StateFromRequest(logger handlers.Serializer, request StatefulRequest, source lib.PlanetScaleSource, shards []string, schemaSelection fivetransdk.Selection_WithSchema) (*lib.SyncState, error) {
 	syncState := lib.SyncState{
 		Keyspaces: map[string]lib.KeyspaceState{},
 	}

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -120,7 +120,7 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 			logger.Info(preamble + "no new rows found, exiting")
 			return TableCursorToSerializedCursor(currentPosition)
 		}
-		logger.Info(fmt.Sprintf("new rows found, syncing rows for %v", readDuration))
+		logger.Info(fmt.Sprintf(preamble+"new rows found, syncing rows for %v", readDuration))
 		logger.Info(fmt.Sprintf(preamble+"syncing rows with cursor [%v]", currentPosition))
 
 		currentPosition, err = p.sync(ctx, logger, tableName, columns, currentPosition, latestCursorPosition, ps, tabletType, readDuration, onResult, onCursor, onUpdate)
@@ -144,7 +144,7 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 				logger.Info(fmt.Sprintf("%vFinished reading all rows for table [%v]", preamble, tableName))
 				return currentSerializedCursor, nil
 			} else {
-				logger.Info(fmt.Sprintf("non-grpc error [%v]]", err))
+				logger.Info(fmt.Sprintf(preamble+"non-grpc error [%v]]", err))
 				return currentSerializedCursor, err
 			}
 		}
@@ -159,6 +159,8 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 		err    error
 		client psdbconnect.ConnectClient
 	)
+
+	preamble := fmt.Sprintf("[%v:%v shard : %v] ", ps.Database, tableName, tc.Shard)
 
 	if p.clientFn == nil {
 		conn, err := grpcclient.Dial(ctx, ps.Host,
@@ -185,7 +187,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 		tc.Position = ""
 	}
 
-	logger.Info(fmt.Sprintf("Syncing with cursor position : [%v], using last known PK : %v, stop cursor is : [%v]", tc.Position, tc.LastKnownPk != nil, stopPosition))
+	logger.Info(fmt.Sprintf("%s Syncing with cursor position : [%v], using last known PK : %v, stop cursor is : [%v]", preamble, tc.Position, tc.LastKnownPk != nil, stopPosition))
 
 	sReq := &psdbconnect.SyncRequest{
 		TableName:      tableName,

--- a/lib/types.go
+++ b/lib/types.go
@@ -77,3 +77,7 @@ type KeyspaceState struct {
 type SyncState struct {
 	Keyspaces map[string]KeyspaceState `json:"keyspaces"`
 }
+
+// A map of starting GTIDs for every keyspace and shard
+// i.e. { keyspace: { shard: gtid} }
+type StartingGtids map[string]map[string]string


### PR DESCRIPTION
This PR adds the ability to provide starting GTID positions for every keyspace/shard via the configuration form. The provided `StartingGtids` string might look like:
```
"{\"SalesDB\":{\"-80\":\"MySQL56/MYGTID:1-3\",\"80-\":\"MySQL56/MYOTHERGTID:1-3\"}}"
```

It also modifies the logs so that all logs have a `preamble`.

## Local example
By passing in an initial `starting_gtids` value of:
```
"{\"sharded\": {\"-80\": \"MySQL56/2d3177b6-00ff-11ef-a001-d6899245417e:1-152,2dcd54e6-00ff-11ef-80a9-e27694e22958:1-42\",\"80-\": \"MySQL56/2d9fcad8-00ff-11ef-8e1b-7253f4c0fae7:1-42,30a6a374-00ff-11ef-a2f8-7242d0423046:1-159\"}}"
```

from the `customer` table that has `104` records, only the `4` new records _after_ those provided GTIDs are synced:
```
➜  grpcurl -proto connector_sdk.proto -import-path . -plaintext -d '{"selection": {"with_schema": {"include_new_schemas": true, "schemas": [{"included": true, "schema_name": "sharded", "include_new_tables": true, "tables": [{"included": true, "table_name": "corder", "columns": {"customer_id": true, "order_id": true, "price": true, "sku": true}, "include_new_columns": true}, {"included": true, "table_name": "customer", "columns": {"customer_id": true, "email": true}}]}]}}, "configuration": {"host": "aws.connect.psdb.cloud","database": "sharded","username": <REDACTED>, "password": <REDACTED>, "starting_gtids": "{\"sharded\": {\"-80\": \"MySQL56/2d3177b6-00ff-11ef-a001-d6899245417e:1-152,2dcd54e6-00ff-11ef-80a9-e27694e22958:1-42\",\"80-\": \"MySQL56/2d9fcad8-00ff-11ef-8e1b-7253f4c0fae7:1-42,30a6a374-00ff-11ef-a2f8-7242d0423046:1-159\"}}"}}' 127.0.0.1:50051 fivetran_sdk.Connector.Update

{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : -80] peeking to see if there's any new rows"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : -80] new rows found, syncing rows for 1m0s"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : -80] syncing rows with cursor [shard:\"-80\" keyspace:\"sharded\" position:\"MySQL56/2d3177b6-00ff-11ef-a001-d6899245417e:1-152,2dcd54e6-00ff-11ef-80a9-e27694e22958:1-42\"]"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : -80]  Syncing with cursor position : [MySQL56/2d3177b6-00ff-11ef-a001-d6899245417e:1-152,2dcd54e6-00ff-11ef-80a9-e27694e22958:1-42], using last known PK : false, stop cursor is : [MySQL56/2d3177b6-00ff-11ef-a001-d6899245417e:1-200,2dcd54e6-00ff-11ef-80a9-e27694e22958:1-44]"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : -80] Continuing with cursor after server timeout"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : -80] peeking to see if there's any new rows"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : -80] no new rows found, exiting"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : 80-] peeking to see if there's any new rows"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : 80-] new rows found, syncing rows for 1m0s"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : 80-] syncing rows with cursor [shard:\"80-\" keyspace:\"sharded\" position:\"MySQL56/2d9fcad8-00ff-11ef-8e1b-7253f4c0fae7:1-42,30a6a374-00ff-11ef-a2f8-7242d0423046:1-159\"]"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : 80-]  Syncing with cursor position : [MySQL56/2d9fcad8-00ff-11ef-8e1b-7253f4c0fae7:1-42,30a6a374-00ff-11ef-a2f8-7242d0423046:1-159], using last known PK : false, stop cursor is : [MySQL56/2d9fcad8-00ff-11ef-8e1b-7253f4c0fae7:1-91,30a6a374-00ff-11ef-a2f8-7242d0423046:1-198]"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : 80-] Continuing with cursor after server timeout"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : 80-] peeking to see if there's any new rows"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:corder shard : 80-] no new rows found, exiting"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : -80] peeking to see if there's any new rows"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : -80] new rows found, syncing rows for 1m0s"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : -80] syncing rows with cursor [shard:\"-80\" keyspace:\"sharded\" position:\"MySQL56/2d3177b6-00ff-11ef-a001-d6899245417e:1-152,2dcd54e6-00ff-11ef-80a9-e27694e22958:1-42\"]"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : -80]  Syncing with cursor position : [MySQL56/2d3177b6-00ff-11ef-a001-d6899245417e:1-152,2dcd54e6-00ff-11ef-80a9-e27694e22958:1-42], using last known PK : false, stop cursor is : [MySQL56/2d3177b6-00ff-11ef-a001-d6899245417e:1-200,2dcd54e6-00ff-11ef-80a9-e27694e22958:1-44]"
  }
}
{
  "operation": {
    "record": {
      "schemaName": "sharded",
      "tableName": "customer",
      "data": {
        "customer_id": {
          "long": "1102"
        },
        "email": {
          "string": "frances3@planetscale.com"
        }
      }
    }
  }
}
{
  "operation": {
    "record": {
      "schemaName": "sharded",
      "tableName": "customer",
      "data": {
        "customer_id": {
          "long": "1103"
        },
        "email": {
          "string": "frances4@planetscale.com"
        }
      }
    }
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : -80] Continuing with cursor after server timeout"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : -80] peeking to see if there's any new rows"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : -80] no new rows found, exiting"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : 80-] peeking to see if there's any new rows"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : 80-] new rows found, syncing rows for 1m0s"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : 80-] syncing rows with cursor [shard:\"80-\" keyspace:\"sharded\" position:\"MySQL56/2d9fcad8-00ff-11ef-8e1b-7253f4c0fae7:1-42,30a6a374-00ff-11ef-a2f8-7242d0423046:1-159\"]"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : 80-]  Syncing with cursor position : [MySQL56/2d9fcad8-00ff-11ef-8e1b-7253f4c0fae7:1-42,30a6a374-00ff-11ef-a2f8-7242d0423046:1-159], using last known PK : false, stop cursor is : [MySQL56/2d9fcad8-00ff-11ef-8e1b-7253f4c0fae7:1-91,30a6a374-00ff-11ef-a2f8-7242d0423046:1-198]"
  }
}
{
  "operation": {
    "record": {
      "schemaName": "sharded",
      "tableName": "customer",
      "data": {
        "customer_id": {
          "long": "1100"
        },
        "email": {
          "string": "frances@planetscale.com"
        }
      }
    }
  }
}
{
  "operation": {
    "record": {
      "schemaName": "sharded",
      "tableName": "customer",
      "data": {
        "customer_id": {
          "long": "1101"
        },
        "email": {
          "string": "frances2@planetscale.com"
        }
      }
    }
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : 80-] Continuing with cursor after server timeout"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : 80-] peeking to see if there's any new rows"
  }
}
{
  "logEntry": {
    "message": "request-1c46be2f-0eef-4d87-b767-f2632e67cb30 [sharded:customer shard : 80-] no new rows found, exiting"
  }
}
{
  "operation": {
    "checkpoint": {
      "stateJson": "{\"keyspaces\":{\"sharded\":{\"streams\":{\"sharded:corder\":{\"shards\":{\"-80\":{\"cursor\":\"CgMtODASB3NoYXJkZWQaXE15U1FMNTYvMmQzMTc3YjYtMDBmZi0xMWVmLWEwMDEtZDY4OTkyNDU0MTdlOjEtMjAwLDJkY2Q1NGU2LTAwZmYtMTFlZi04MGE5LWUyNzY5NGUyMjk1ODoxLTQ0\"},\"80-\":{\"cursor\":\"CgM4MC0SB3NoYXJkZWQaXE15U1FMNTYvMmQ5ZmNhZDgtMDBmZi0xMWVmLThlMWItNzI1M2Y0YzBmYWU3OjEtOTEsMzBhNmEzNzQtMDBmZi0xMWVmLWEyZjgtNzI0MmQwNDIzMDQ2OjEtMTk4\"}}},\"sharded:customer\":{\"shards\":{\"-80\":{\"cursor\":\"CgMtODASB3NoYXJkZWQaXE15U1FMNTYvMmQzMTc3YjYtMDBmZi0xMWVmLWEwMDEtZDY4OTkyNDU0MTdlOjEtMjAwLDJkY2Q1NGU2LTAwZmYtMTFlZi04MGE5LWUyNzY5NGUyMjk1ODoxLTQ0\"},\"80-\":{\"cursor\":\"CgM4MC0SB3NoYXJkZWQaXE15U1FMNTYvMmQ5ZmNhZDgtMDBmZi0xMWVmLThlMWItNzI1M2Y0YzBmYWU3OjEtOTEsMzBhNmEzNzQtMDBmZi0xMWVmLWEyZjgtNzI0MmQwNDIzMDQ2OjEtMTk4\"}}}}}}}"
    }
  }
}
```