### PR TITLE
Added geomcollection to the list

### DIFF
--- a/cmd/internal/server/handlers/schema_builder.go
+++ b/cmd/internal/server/handlers/schema_builder.go
@@ -289,6 +289,7 @@ func getFivetranDataType(mType string, treatTinyIntAsBoolean bool) (fivetransdk.
 
 	if strings.HasPrefix(mysqlType, "set") ||
 		strings.HasPrefix(mysqlType, "geometry") ||
+		strings.HasPrefix(mysqlType, "geomcollection") ||
 		strings.HasPrefix(mysqlType, "geometrycollection") ||
 		strings.HasPrefix(mysqlType, "multipoint") ||
 		strings.HasPrefix(mysqlType, "multipolygon") ||


### PR DESCRIPTION
@notfelineit,

I'm hoping this may be all that's required to get past the hurdle our user reported.

I was going to copy the following lines as well and create an entry for `GEOMCOLLECTION` that would be similar:
https://github.com/planetscale/fivetran-source/blob/0797ecb649f698a07aea75b3b636cabaacebba1b/cmd/internal/server/server_test.go#L205-L210

But attempting to run a query like this fails in regular MySQL as well as on a PlanetScale database:
```sql
-- Works:
Select ST_GeomFromText("GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))");

-- Doesn't work: SQL Error [3037] [22001]: Data truncation: Invalid GIS data provided to function st_geomfromtext.
Select ST_GeomFromText("GEOMCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))");
``` 

So I think in the context of a query like the one above `GEOMETRYCOLLECTION` probably always has to be used but that's separate from the MySQL column types.

Given the above, I didn't make any changes within the `server_test.go` file and only made the minor addition into the `schema_builder.go` file to add the `geomcollection` type into the list.

My current hope is that simply adding in `geomcollection` into the list within `schema_builder.go` will be enough to support columns using that type within user schemas 🙏 .