### PR TITLE
Filter columns before sync

### DIFF
--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -108,7 +108,7 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 
 	currentPosition := lastKnownPosition
 	readDuration := 1 * time.Minute
-	preamble := fmt.Sprintf("[%v:%v shard : %v] ", ps.Database, tableName, currentPosition.Shard)
+	preamble := fmt.Sprintf("[%v:%v shard:%v tabletType:%s] ", ps.Database, tableName, currentPosition.Shard, tabletType)
 
 	existingColumns, err := p.filterExistingColumns(ctx, ps, tableName, columns)
 	if err != nil {

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -300,7 +300,7 @@ func (p connectClient) filterExistingColumns(ctx context.Context, ps PlanetScale
 		}
 
 	}
-	return existingColumns, nil
+	return existingColumns, err
 }
 
 func serializeQueryResult(result *query.QueryResult) *sqltypes.Result {

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -112,10 +112,10 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 
 	existingColumns, err := p.filterExistingColumns(ctx, ps, tableName, columns)
 	if err != nil {
-		logger.Info(fmt.Sprintf("%s Couldn't fetch existing columns, falling back to requested columns: %s", preamble, err.Error()))
+		logger.Info(fmt.Sprintf("%sCouldn't fetch existing columns, falling back to requested columns: %s", preamble, err.Error()))
 	}
 
-	logger.Info(fmt.Sprintf("%s Filtering with columns %s", preamble, strings.Join(existingColumns, ",")))
+	logger.Info(fmt.Sprintf("%sFiltering with columns %s", preamble, strings.Join(existingColumns, ",")))
 
 	for {
 		logger.Info(preamble + "peeking to see if there's any new rows")
@@ -144,7 +144,7 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 			if s, ok := status.FromError(err); ok {
 				// if the error is anything other than server timeout, keep going
 				if s.Code() != codes.DeadlineExceeded {
-					logger.Info(fmt.Sprintf("%v Got error [%v] with message [%q], Returning with cursor :[%v] after server timeout", preamble, s.Code(), err, currentPosition))
+					logger.Info(fmt.Sprintf("%vGot error [%v] with message [%q], Returning with cursor :[%v] after server timeout", preamble, s.Code(), err, currentPosition))
 					return currentSerializedCursor, nil
 				} else {
 					logger.Info(preamble + "Continuing with cursor after server timeout")
@@ -169,7 +169,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 		client psdbconnect.ConnectClient
 	)
 
-	preamble := fmt.Sprintf("[%v:%v shard : %v] ", ps.Database, tableName, tc.Shard)
+	preamble := fmt.Sprintf("[%v:%v shard:%v tabletType:%s] ", ps.Database, tableName, tc.Shard, tabletType)
 
 	if p.clientFn == nil {
 		conn, err := grpcclient.Dial(ctx, ps.Host,
@@ -196,7 +196,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 		tc.Position = ""
 	}
 
-	logger.Info(fmt.Sprintf("%s Syncing with cursor position : [%v], using last known PK : %v, stop cursor is : [%v]", preamble, tc.Position, tc.LastKnownPk != nil, stopPosition))
+	logger.Info(fmt.Sprintf("%sSyncing with cursor position : [%v], using last known PK : %v, stop cursor is : [%v]", preamble, tc.Position, tc.LastKnownPk != nil, stopPosition))
 
 	sReq := &psdbconnect.SyncRequest{
 		TableName:      tableName,

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -192,7 +192,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 
 	existingColumns, err := p.filterExistingColumns(ctx, ps, tableName, columns)
 	if err != nil {
-		logger.Info(fmt.Sprintf("%s Couldn't fetch existing columns, falling back to requested columns", preamble))
+		logger.Info(fmt.Sprintf("%s Couldn't fetch existing columns, falling back to requested columns: %s", preamble, err.Error()))
 	}
 
 	logger.Info(fmt.Sprintf("%s Filtering with columns %s", preamble, strings.Join(existingColumns, ",")))

--- a/lib/connect_client_test.go
+++ b/lib/connect_client_test.go
@@ -19,6 +19,11 @@ import (
 func TestRead_CanPeekBeforeRead(t *testing.T) {
 	dbl := &dbLogger{}
 	ped := connectClient{}
+	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+		return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}, {Name: "email", Type: "varchar(256)", IsPrimaryKey: false}}, nil
+	}
+	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+	ped.Mysql = &mysqlClient
 	tc := &psdbconnect.TableCursor{
 		Shard:    "-",
 		Position: "THIS_IS_A_SHARD_GTID",
@@ -63,6 +68,11 @@ func TestRead_CanPeekBeforeRead(t *testing.T) {
 func TestRead_CanEarlyExitIfNoNewVGtidInPeek(t *testing.T) {
 	dbl := &dbLogger{}
 	ped := connectClient{}
+	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+		return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}, {Name: "email", Type: "varchar(256)", IsPrimaryKey: false}}, nil
+	}
+	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+	ped.Mysql = &mysqlClient
 	tc := &psdbconnect.TableCursor{
 		Shard:    "-",
 		Position: "THIS_IS_A_SHARD_GTID",
@@ -103,6 +113,11 @@ func TestRead_CanEarlyExitIfNoNewVGtidInPeek(t *testing.T) {
 func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	dbl := &dbLogger{}
 	ped := connectClient{}
+	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+		return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}, {Name: "email", Type: "varchar(256)", IsPrimaryKey: false}}, nil
+	}
+	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+	ped.Mysql = &mysqlClient
 	tc := &psdbconnect.TableCursor{
 		Shard:    "40-80",
 		Position: "THIS_IS_A_SHARD_GTID",
@@ -145,6 +160,11 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 func TestRead_CanPickReplicaForShardedKeyspaces(t *testing.T) {
 	dbl := &dbLogger{}
 	ped := connectClient{}
+	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+		return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}, {Name: "email", Type: "varchar(256)", IsPrimaryKey: false}}, nil
+	}
+	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+	ped.Mysql = &mysqlClient
 	tc := &psdbconnect.TableCursor{
 		Shard:    "40-80",
 		Position: "THIS_IS_A_SHARD_GTID",
@@ -351,7 +371,7 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 	assert.Equal(t, esc, sc)
 	assert.Equal(t, 2, cc.syncFnInvokedCount)
 
-	assert.Equal(t, "[connect-test:customers shard : -] Finished reading all rows for table [customers]", dbl.messages[len(dbl.messages)-1].message)
+	assert.Equal(t, "[connect-test:customers shard:- tabletType:primary] Finished reading all rows for table [customers]", dbl.messages[len(dbl.messages)-1].message)
 	assert.Equal(t, 2*(nextVGtidPosition/3), insertedRowCounter)
 	assert.Equal(t, 2*(nextVGtidPosition/3), deletedRowCounter)
 }

--- a/lib/connect_client_test.go
+++ b/lib/connect_client_test.go
@@ -223,6 +223,13 @@ func TestRead_CanReturnNewCursorIfNewFound(t *testing.T) {
 	onCursor := func(*psdbconnect.TableCursor) error {
 		return nil
 	}
+
+	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+		return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}, {Name: "email", Type: "varchar(256)", IsPrimaryKey: false}}, nil
+	}
+	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+	ped.Mysql = &mysqlClient
+
 	sc, err := ped.Read(context.Background(), dbl, ps, "customers", nil, tc, onRow, onCursor, nil)
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(newTC)
@@ -327,6 +334,13 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 	onCursor := func(*psdbconnect.TableCursor) error {
 		return nil
 	}
+
+	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+		return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}, {Name: "email", Type: "varchar(256)", IsPrimaryKey: false}}, nil
+	}
+	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+	ped.Mysql = &mysqlClient
+
 	sc, err := ped.Read(context.Background(), dbl, ps, "customers", nil, responses[0].Cursor, onRow, onCursor, nil)
 
 	assert.NoError(t, err)
@@ -346,7 +360,11 @@ func TestRead_FiltersNonExistentColumns(t *testing.T) {
 	ped := connectClient{}
 
 	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
-		return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}, {Name: "email", Type: "varchar(256)", IsPrimaryKey: false}}, nil
+		return []MysqlColumn{
+			{Name: "id", Type: "bigint", IsPrimaryKey: true},
+			{Name: "email", Type: "varchar(256)", IsPrimaryKey: false},
+			{Name: "name", Type: "varchar(256)", IsPrimaryKey: false},
+		}, nil
 	}
 	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
 	ped.Mysql = &mysqlClient

--- a/lib/mysql_client.go
+++ b/lib/mysql_client.go
@@ -15,6 +15,7 @@ type MysqlClient interface {
 	BuildSchema(ctx context.Context, psc PlanetScaleSource, schemaBuilder SchemaBuilder) error
 	PingContext(context.Context, PlanetScaleSource) error
 	GetVitessShards(ctx context.Context, psc PlanetScaleSource) ([]string, error)
+	GetKeyspaceTableColumns(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error)
 	Close() error
 }
 
@@ -54,7 +55,7 @@ func (p mysqlClient) BuildSchema(ctx context.Context, psc PlanetScaleSource, sch
 		for _, tableName := range tableNames {
 			schemaBuilder.OnTable(keyspaceName, tableName)
 
-			columns, err := p.getKeyspaceTableColumns(ctx, keyspaceName, tableName)
+			columns, err := p.GetKeyspaceTableColumns(ctx, keyspaceName, tableName)
 			if err != nil {
 				return errors.Wrap(err, "Unable to build schema for database")
 			}
@@ -70,7 +71,7 @@ func (p mysqlClient) Close() error {
 	return p.db.Close()
 }
 
-func (p mysqlClient) getKeyspaceTableColumns(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+func (p mysqlClient) GetKeyspaceTableColumns(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
 	var columns []MysqlColumn
 	columnNamesQR, err := p.db.QueryContext(
 		ctx,


### PR DESCRIPTION
This PR adds a column filter before making a sync request to psdbconnect. Columns that do not currently exist in the PSDB's schema are filtered out, so we only request columns that exist. This is because VStream fails when passing a [filter](https://vitess.io/docs/20.0/reference/vreplication/vstream/#filter) containing non-existent columns.

**To do:**
- [x] Write tests
- [x] Test locally