### PR TITLE
Modified regex and tests for new Vitess table names

### DIFF
--- a/cmd/internal/server/handlers/schema_builder.go
+++ b/cmd/internal/server/handlers/schema_builder.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	gCTableNameExpression    string = `^_vt_(HOLD|PURGE|EVAC|DROP)_([0-f]{32})_([0-9]{14})$`
+	gCTableNameExpression    string = `_[0-9a-zA-Z]{8}_[0-9a-zA-Z]{4}_[0-9a-zA-Z]{4}_.*|_vt_.*`
 	vreplTableNameExpression string = `\b_(\w+|\d+)_\d+_vrepl\b`
 )
 

--- a/cmd/internal/server/handlers/schema_builder_test.go
+++ b/cmd/internal/server/handlers/schema_builder_test.go
@@ -14,6 +14,16 @@ func TestCanIgnoreVitessGCTables(t *testing.T) {
 	sb := NewSchemaBuilder(true)
 	sb.OnKeyspace("Employees")
 
+	// Newer style Vitess tables to filter:
+	sb.OnTable("Employees", "_vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_")
+	sb.OnTable("Employees", "_vt_prg_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_")
+	sb.OnTable("Employees", "_vt_evc_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_")
+	sb.OnTable("Employees", "_vt_drp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_")
+	sb.OnTable("Employees", "_vt_vrp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_")
+	sb.OnTable("Employees", "_vt_gho_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_")
+	sb.OnTable("Employees", "_vt_ghc_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_")
+	sb.OnTable("Employees", "_vt_del_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_")
+
 	sb.OnTable("Employees", "_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20200915120410")
 	sb.OnTable("Employees", "_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410")
 	sb.OnTable("Employees", "_vt_EVAC_6ace8bcef73211ea87e9f875a4d24e90_20200915120410")


### PR DESCRIPTION
Used the same regex from:
https://github.com/planetscale/api-bb/pull/14322

For the Fivetran connector I wasn't directly able to re-run the test function after adjusting the regex and adding the extra test cases in but based on the experience with the Airbyte connector change this should hopefully still address what was described in https://github.com/planetscale/surfaces/issues/3084.