### PR TITLE
Return nil to allow other tables to sync

### DIFF
--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -159,7 +159,7 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 
 					if consecutiveTimeouts >= maxConsecutiveTimeouts {
 						logger.Info(fmt.Sprintf("%sReached maximum consecutive timeouts (%d), stopping sync", preamble, maxConsecutiveTimeouts))
-						return currentSerializedCursor, errors.New("maximum consecutive timeouts reached")
+						return currentSerializedCursor, nil
 					}
 
 					// Apply exponential backoff


### PR DESCRIPTION
### Description of change
Point 5 in this [PR](https://github.com/planetscale/fivetran-source/pull/63)'s description was not pushed in that PR by mistake. This PR fixes it. 

> Non-Blocking Max Timeout Handling
> Returns nil instead of error when max retries are exceeded to allow other tables to continue.