### PR TITLE
Call Truncate only when all shards have empty positions

### DIFF
--- a/cmd/internal/server/server_test.go
+++ b/cmd/internal/server/server_test.go
@@ -311,7 +311,7 @@ func geometryTypeTest(t *testing.T, geometry []byte, geojson string) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 5)
+	assert.Len(t, rows, 4)
 	operation := rows[1].GetOperation()
 	require.NotNil(t, operation)
 	record, ok := operation.(*fivetransdk.UpdateResponse_Record)
@@ -409,8 +409,8 @@ func TestUpdateReturnsInserts(t *testing.T) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 5)
-	operation := rows[3].GetOperation()
+	assert.Len(t, rows, 4)
+	operation := rows[2].GetOperation()
 	require.NotNil(t, operation)
 	record, ok := operation.(*fivetransdk.UpdateResponse_Record)
 	assert.True(t, ok)
@@ -610,8 +610,8 @@ func TestUpdateReturnsDeletes(t *testing.T) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 5)
-	operation := rows[3].GetOperation()
+	assert.Len(t, rows, 4)
+	operation := rows[2].GetOperation()
 	assert.NotNil(t, operation)
 	record, ok := operation.(*fivetransdk.UpdateResponse_Record)
 	assert.True(t, ok)
@@ -729,8 +729,8 @@ func TestUpdateReturnsUpdates(t *testing.T) {
 		}
 		rows = append(rows, resp)
 	}
-	assert.Len(t, rows, 5)
-	operation := rows[3].GetOperation()
+	assert.Len(t, rows, 4)
+	operation := rows[2].GetOperation()
 	assert.NotNil(t, operation)
 	record, ok := operation.(*fivetransdk.UpdateResponse_Record)
 	assert.True(t, ok)


### PR DESCRIPTION
### Issue
The operation `logger.Truncate(ks, table)` was being called if `tc.Position == ""` evaluates to `true`. This is correct in the sense that if `Position` is empty then it means that it is an initial sync which means that `logger.Truncate(ks, table)` can rightly be called. 
However, this has a major flaw: It can be only be concluded that it is an initial sync if `Position` is empty for **all** shards of a given table. 

### Fix
We perform two passes over all shards of a table - first pass checks if `Position` is empty for all shards, the second pass performs the actual sync. 