### PR TITLE
Prevent incorrect cursor progression for a shard

### DIFF
--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -154,14 +154,14 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 				// if the error is anything other than server timeout, keep going
 				if s.Code() != codes.DeadlineExceeded {
 					logger.Info(fmt.Sprintf("%vGot error [%v] with message [%q], Returning with cursor :[%v] after non-timeout error", preamble, s.Code(), err, currentPosition))
-					return nil, nil
+					return nil, nil // Return nil for cursor to prevent incorrect cursor progression, nil for error to allow other shards to sync
 				} else {
 					consecutiveTimeouts++
 					logger.Info(fmt.Sprintf("%sTimeout occurred (%d/%d consecutive timeouts)", preamble, consecutiveTimeouts, maxConsecutiveTimeouts))
 
 					if consecutiveTimeouts >= maxConsecutiveTimeouts {
 						logger.Info(fmt.Sprintf("%sReached maximum consecutive timeouts (%d), stopping sync", preamble, maxConsecutiveTimeouts))
-						return nil, nil
+						return nil, nil // Return nil for cursor to prevent incorrect cursor progression, nil for error to allow other shards to sync
 					}
 
 					// Apply exponential backoff

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -154,14 +154,14 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 				// if the error is anything other than server timeout, keep going
 				if s.Code() != codes.DeadlineExceeded {
 					logger.Info(fmt.Sprintf("%vGot error [%v] with message [%q], Returning with cursor :[%v] after non-timeout error", preamble, s.Code(), err, currentPosition))
-					return currentSerializedCursor, nil
+					return nil, nil
 				} else {
 					consecutiveTimeouts++
 					logger.Info(fmt.Sprintf("%sTimeout occurred (%d/%d consecutive timeouts)", preamble, consecutiveTimeouts, maxConsecutiveTimeouts))
 
 					if consecutiveTimeouts >= maxConsecutiveTimeouts {
 						logger.Info(fmt.Sprintf("%sReached maximum consecutive timeouts (%d), stopping sync", preamble, maxConsecutiveTimeouts))
-						return currentSerializedCursor, nil
+						return nil, nil
 					}
 
 					// Apply exponential backoff


### PR DESCRIPTION
### Current logic

We iterate over all shards for a table, for each shard we:
1. Sync data
2. Save the cursor
3. Proceed to next shard

### Fix 

- In case of errors while syncing data from a shard, we should return `nil` as the cursor value so that it does not progress incorrectly. 
- In order to not fail the sync process and allow data from other shards to sync, we don't want to return the error back. 

Hence we should return `nil, nil` instead of returning `currentSerializedCursor, err`