### PR TITLE
Fix: handle `tinyint(1)` BOOLEAN inference with modifiers like NOT NULL

### DIFF
--- a/cmd/internal/server/handlers/schema_builder.go
+++ b/cmd/internal/server/handlers/schema_builder.go
@@ -230,8 +230,20 @@ func parseEnumOrSetValues(mType string) ValueMap {
 // Convert columnType to fivetran type
 func getFivetranDataType(mType string, treatTinyIntAsBoolean bool) (fivetransdk.DataType, *fivetransdk.DecimalParams) {
 	mysqlType := strings.ToLower(mType)
+	// only interested in first part of the schema output to avoid issues with NOT NULL
+	parts := strings.Fields(mysqlType)
+
+	// empty schema condition
+	if len(parts) == 0 {
+		return fivetransdk.DataType_UNSPECIFIED, nil
+	}
+
+	// get first entry from non zero length slice of column type definition
+	baseType := parts[0]
+
+	// modified conditional to include baseType to only accept tinyint(1)
 	if strings.HasPrefix(mysqlType, "tinyint") {
-		if treatTinyIntAsBoolean && mysqlType == "tinyint(1)" {
+		if treatTinyIntAsBoolean && baseType == "tinyint(1)" {
 			return fivetransdk.DataType_BOOLEAN, nil
 		}
 

--- a/cmd/internal/server/handlers/schema_builder_test.go
+++ b/cmd/internal/server/handlers/schema_builder_test.go
@@ -256,3 +256,29 @@ func TestCanDetectDecimalPrecision(t *testing.T) {
 		})
 	}
 }
+
+// Adding an additional unit test for the tinyint(1) as bool handling since the orginals were not wide enough
+func TestGetFivetranDataType_TinyintBooleanHandling(t *testing.T) {
+	tests := []struct {
+		mysqlType             string
+		treatTinyIntAsBoolean bool
+		expected              fivetransdk.DataType
+	}{
+		{"tinyint(1)", true, fivetransdk.DataType_BOOLEAN},
+		{"tinyint(1) NOT NULL", true, fivetransdk.DataType_BOOLEAN},
+		{"tinyint(1) unsigned", true, fivetransdk.DataType_BOOLEAN},
+		{"tinyint(2)", true, fivetransdk.DataType_INT},
+		{"tinyint", true, fivetransdk.DataType_INT},
+		{"TINYINT(1)", true, fivetransdk.DataType_BOOLEAN},
+		{"tinyint(1)", false, fivetransdk.DataType_INT},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_bool_%t", tt.mysqlType, tt.treatTinyIntAsBoolean), func(t *testing.T) {
+			got, _ := getFivetranDataType(tt.mysqlType, tt.treatTinyIntAsBoolean)
+			if got != tt.expected {
+				t.Errorf("For input '%s', expected %s but got %s", tt.mysqlType, tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Problem

The `getFivetranDataType` function originally only returned `BOOLEAN` if the MySQL type was *exactly* `"tinyint(1)"`. This excluded common real-world variants like:

- `tinyint(1) NOT NULL`
- `tinyint(1) unsigned`
- `tinyint(1) zerofill`
- `TINYINT(1)` (case insensitivity)

These types should be safely treated as booleans when `treatTinyIntAsBoolean` is enabled — which matches MySQL connector behavior and expectations from most CDC systems.

---

### Fix

The logic has been updated to:
- Normalize `mysqlType` to lowercase
- Split it by whitespace (using `strings.Fields`)
- Only evaluate the **base type** (e.g., `"tinyint(1)"`) for the boolean match

This avoids false negatives while ensuring that `tinyint(2+)` are not misclassified as booleans.

---

### Test Coverage

Added unit tests for:

- `tinyint(1)` -- Pass 
- `tinyint(1) NOT NULL` --  Pass
- `tinyint(1) unsigned` -- Pass
- `tinyint(2)` -- Fail
- `tinyint` -- Fail
- `TINYINT(1)` -- Pass

Added an additional unit test to include these parameters as the original did not include these edge cases 