### PR TITLE
Fix(Fivetran): Json conversion empty string to null

### DIFF
--- a/cmd/internal/server/handlers/fivetran_value_converters_test.go
+++ b/cmd/internal/server/handlers/fivetran_value_converters_test.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"testing"
+
+	fivetransdk "github.com/planetscale/fivetran-source/fivetran_sdk.v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/sqltypes"
+)
+
+func TestJSONConverter_EmptyString(t *testing.T) {
+	converter, err := GetConverter(fivetransdk.DataType_JSON)
+	require.NoError(t, err)
+
+	// Empty string should convert to NULL for BigQuery compatibility
+	emptyValue := sqltypes.NewVarChar("")
+	result, err := converter(emptyValue)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	_, ok := result.Inner.(*fivetransdk.ValueType_Null)
+	assert.True(t, ok, "empty JSON string should convert to NULL")
+}
+
+func TestJSONConverter_ValidJSON(t *testing.T) {
+	converter, err := GetConverter(fivetransdk.DataType_JSON)
+	require.NoError(t, err)
+
+	// Valid JSON should pass through
+	jsonValue := sqltypes.NewVarChar(`{"key": "value"}`)
+	result, err := converter(jsonValue)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	json, ok := result.Inner.(*fivetransdk.ValueType_Json)
+	require.True(t, ok)
+	assert.Equal(t, `{"key": "value"}`, json.Json)
+}


### PR DESCRIPTION
---
### Issue Description

  Connector Source: PlanetScale (Partner SDK)
  Destination: BigQuery (Fivetran managed)
  Error: Sync failures with JSON parsing errors

### Error Message

  attempting to parse an empty input; check that your input string or stream contains the expected JSON

### What's Happening

  1. Source Database State: PlanetScale database contains empty strings ('') stored in JSON columns (e.g., context and event_log columns)
  2. Sync Process: The PlanetScale connector reads these empty strings and sends them to BigQuery as JSON values
  3. BigQuery Validation: BigQuery's JSON type strictly validates input and rejects empty strings as invalid JSON, causing the sync to fail

 ### Impact

  - Syncs are completely blocked when encountering tables with empty JSON strings
  - Affects all rows in the table, not just rows with empty values
  - Requires manual intervention to resume syncs

 ### Description of the change
 
- added empty string check when handling JSON values, convert empty string to NULL
  ---