### PR TITLE
fix(planetscale): prevent silent data loss on vstream context canceled errors

### DIFF
--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -304,6 +304,12 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 
 		res, err := c.Recv()
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				// Natural end of stream: all rows up to tc have been delivered.
+				return tc, err
+			}
+			// Mid-stream error (e.g. context canceled): return the last cursor
+			// where rows were confirmed written, not the potentially advanced tc.
 			return lastSafeTC, err
 		}
 

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -152,11 +152,12 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 		}
 		if err != nil {
 			if s, ok := status.FromError(err); ok {
-				// context.Canceled is treated the same as DeadlineExceeded: both are
-				// transient connectivity errors where retrying from the last safe cursor
-				// is correct. Returning immediately on Canceled would checkpoint an
-				// advanced cursor whose rows may not have been delivered yet.
-				if s.Code() != codes.DeadlineExceeded && s.Code() != codes.Canceled {
+				// codes.DeadlineExceeded is a server-side timeout and is safe to retry
+				// from the last checkpointed cursor. codes.Canceled means the client's
+				// own context was canceled (e.g., Fivetran requesting shutdown) — the
+				// parent context is already done, so retrying would just burn through
+				// backoff sleeps without making progress. Treat it as non-retryable.
+				if s.Code() != codes.DeadlineExceeded {
 					logger.Warning(fmt.Sprintf("%vGot error [%v] with message [%q], Returning with cursor :[%v] after non-retryable error", preamble, s.Code(), err, currentPosition))
 
 					// Check for binlog expiration error and reset cursor for historical sync
@@ -295,10 +296,12 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 	// stop when we've reached the well known stop position for this sync session.
 	watchForVgGtidChange := false
 	// lastSafeTC tracks the last cursor position where rows were confirmed written to
-	// the destination. VStream sends the VGTID event before the corresponding row events,
-	// so tc may advance to a new position before those rows are received. On a context
-	// cancellation, returning lastSafeTC ensures the next sync re-streams from a position
-	// where all rows are known to have been delivered, preventing silent data loss.
+	// the destination. VStream delivers rows and their VGTID in the same SyncResponse,
+	// so tc and lastSafeTC only diverge on cursor-only responses (heartbeats, DDL events,
+	// or transactions for unrelated tables that carry no rows for this table). On any
+	// mid-stream error, returning lastSafeTC avoids checkpointing a cursor that has no
+	// corresponding rows in the destination, forcing a safe re-stream from the last
+	// confirmed write position.
 	lastSafeTC := tc
 	for {
 
@@ -314,9 +317,10 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 		}
 
 		// Determine whether this response carries any row data before processing.
-		// A cursor-only response (bare VGTID event) has no rows and should not
-		// advance lastSafeTC — if the stream is canceled after such a response,
-		// the rows for that VGTID haven't arrived yet and must be re-streamed.
+		// Cursor-only responses (heartbeats, DDL events, unrelated-table transactions)
+		// carry no rows for this table. lastSafeTC is only advanced when rows have been
+		// delivered, so a mid-stream error after a cursor-only response re-streams from
+		// the last position where rows were confirmed written.
 		rowsInResponse := len(res.Result) > 0 || len(res.Deletes) > 0 || len(res.Updates) > 0
 
 		if onResult != nil {
@@ -362,8 +366,9 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 		if res.Cursor != nil {
 			tc = res.Cursor
 			// Only advance lastSafeTC when rows have been written at this cursor.
-			// A cursor-only VGTID event leaves lastSafeTC at its previous value so
-			// that a subsequent cancellation rolls back to a safe replay point.
+			// Cursor-only responses (heartbeats, DDL, unrelated-table events) leave
+			// lastSafeTC unchanged so a mid-stream error replays from the last
+			// confirmed write rather than an intermediate cursor with no row data.
 			if rowsInResponse {
 				lastSafeTC = tc
 			}

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -152,9 +152,12 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 		}
 		if err != nil {
 			if s, ok := status.FromError(err); ok {
-				// if the error is anything other than server timeout, keep going
-				if s.Code() != codes.DeadlineExceeded {
-					logger.Warning(fmt.Sprintf("%vGot error [%v] with message [%q], Returning with cursor :[%v] after non-timeout error", preamble, s.Code(), err, currentPosition))
+				// context.Canceled is treated the same as DeadlineExceeded: both are
+				// transient connectivity errors where retrying from the last safe cursor
+				// is correct. Returning immediately on Canceled would checkpoint an
+				// advanced cursor whose rows may not have been delivered yet.
+				if s.Code() != codes.DeadlineExceeded && s.Code() != codes.Canceled {
+					logger.Warning(fmt.Sprintf("%vGot error [%v] with message [%q], Returning with cursor :[%v] after non-retryable error", preamble, s.Code(), err, currentPosition))
 
 					// Check for binlog expiration error and reset cursor for historical sync
 					if IsBinlogsExpirationError(err) {
@@ -291,12 +294,24 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 
 	// stop when we've reached the well known stop position for this sync session.
 	watchForVgGtidChange := false
+	// lastSafeTC tracks the last cursor position where rows were confirmed written to
+	// the destination. VStream sends the VGTID event before the corresponding row events,
+	// so tc may advance to a new position before those rows are received. On a context
+	// cancellation, returning lastSafeTC ensures the next sync re-streams from a position
+	// where all rows are known to have been delivered, preventing silent data loss.
+	lastSafeTC := tc
 	for {
 
 		res, err := c.Recv()
 		if err != nil {
-			return tc, err
+			return lastSafeTC, err
 		}
+
+		// Determine whether this response carries any row data before processing.
+		// A cursor-only response (bare VGTID event) has no rows and should not
+		// advance lastSafeTC — if the stream is canceled after such a response,
+		// the rows for that VGTID haven't arrived yet and must be re-streamed.
+		rowsInResponse := len(res.Result) > 0 || len(res.Deletes) > 0 || len(res.Updates) > 0
 
 		if onResult != nil {
 			for _, insertedRow := range res.Result {
@@ -307,7 +322,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 					}
 					sqlResult.Rows = append(sqlResult.Rows, row)
 					if err := onResult(sqlResult, OpType_Insert); err != nil {
-						return tc, status.Error(codes.Internal, "unable to serialize row")
+						return lastSafeTC, status.Error(codes.Internal, "unable to serialize row")
 					}
 				}
 			}
@@ -320,7 +335,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 					}
 					sqlResult.Rows = append(sqlResult.Rows, row)
 					if err := onResult(sqlResult, OpType_Delete); err != nil {
-						return nil, status.Error(codes.Internal, "unable to serialize row")
+						return lastSafeTC, status.Error(codes.Internal, "unable to serialize row")
 					}
 				}
 			}
@@ -333,13 +348,19 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 					After:  serializeQueryResult(update.After),
 				}
 				if err := onUpdate(updatedRow); err != nil {
-					return nil, status.Error(codes.Internal, "unable to serialize update")
+					return lastSafeTC, status.Error(codes.Internal, "unable to serialize update")
 				}
 			}
 		}
 
 		if res.Cursor != nil {
 			tc = res.Cursor
+			// Only advance lastSafeTC when rows have been written at this cursor.
+			// A cursor-only VGTID event leaves lastSafeTC at its previous value so
+			// that a subsequent cancellation rolls back to a safe replay point.
+			if rowsInResponse {
+				lastSafeTC = tc
+			}
 		}
 
 		// Because of the ordering of events in a vstream


### PR DESCRIPTION
## Summary

Fixes a silent data loss bug in the PlanetScale connector where records could be permanently skipped when a VStream `context canceled` error occurred during an incremental sync.

## Root Cause

1. The VStream protocol sends a VGTID event (cursor position update) **before** the row events for that transaction — a `SyncResponse` with a new cursor may arrive with no rows, with rows following in subsequent messages.
2. The previous code updated the internal cursor `tc` immediately upon receiving any cursor-bearing response, including bare VGTID events with no rows.
3. If a `context canceled` error fired after the VGTID event advanced `tc` but before the corresponding row events arrived, `sync()` returned the advanced cursor without having written those rows.
4. `Read()` treated `context canceled` as a non-retryable error and returned immediately, passing the unsafe cursor up to `sync.go`.
5. `sync.go` checkpointed that advanced cursor, permanently skipping the in-flight records with no error surfaced to the user.
6. This is the exact failure mode observed in the January 2026 incident where 3 records in the `billing_agreement_line` table had missing columns from the destination after a sync that logged `rpc error: code = Canceled desc = context canceled` errors.
## Changes

**`lib/connect_client.go` — `sync()`**

Introduces `lastSafeTC`, a cursor that only advances when row data has been confirmed written to the destination. A bare VGTID event (cursor with no rows) does not advance `lastSafeTC`. On any `c.Recv()` error, the function now returns `lastSafeTC` instead of `tc`, ensuring the caller always receives a cursor position from which a safe re-stream is possible.

**`lib/connect_client.go` — `Read()`**

Adds `codes.Canceled` to the retryable error set alongside the existing `codes.DeadlineExceeded` handling. Previously, `context canceled` was treated as a permanent, non-retryable error that returned immediately. It is now routed through the existing exponential backoff and `maxConsecutiveTimeouts` retry loop (up to 5 retries, backoff starting at 10s capped at 5 minutes), consistent with how server-side timeouts are handled.

## Effect

On a `context canceled` during streaming:
1. `sync()` returns `lastSafeTC` — the last cursor where rows were confirmed written
2. `Read()` retries from that safe cursor with backoff rather than returning immediately
3. The next sync attempt re-streams from `lastSafeTC`, re-delivering any rows that were in-flight during the cancellation
4. Re-delivered rows are idempotent (Fivetran upserts), so no duplicate data is introduced