### PR TITLE
Fix BIT value conversion

### DIFF
--- a/cmd/internal/server/handlers/fivetran_value_converters.go
+++ b/cmd/internal/server/handlers/fivetran_value_converters.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"math"
 	"strconv"
@@ -75,16 +74,9 @@ var converters = map[fivetransdk.DataType]ConverterFunc{
 			return nil, errors.Wrap(err, "failed to serialize Type_BIT")
 		}
 
-		// Varint decodes an int64 from buf and returns that value and the
-		// number of bytes read (> 0). If an error occurred, the value is 0
-		// and the number of bytes n is <= 0 with the following meaning:
-		//
-		//	n == 0: buf too small
-		//	n  < 0: value larger than 64 bits (overflow)
-		//	        and -n is the number of bytes read
-		i, n := binary.Varint(b)
-		if n <= 0 {
-			return nil, fmt.Errorf("failed to serialize DataType_LONG, read %v bytes", n)
+		i, err := bitBytesToInt64(b)
+		if err != nil {
+			return nil, err
 		}
 
 		return &fivetransdk.ValueType{
@@ -228,6 +220,22 @@ var converters = map[fivetransdk.DataType]ConverterFunc{
 			Inner: &fivetransdk.ValueType_Json{Json: jsonString},
 		}, nil
 	},
+}
+
+func bitBytesToInt64(b []byte) (int64, error) {
+	if len(b) > 8 {
+		return 0, fmt.Errorf("failed to serialize Type_BIT: value uses %d bytes", len(b))
+	}
+
+	var u uint64
+	for _, by := range b {
+		u = (u << 8) | uint64(by)
+	}
+	if u > math.MaxInt64 {
+		return 0, fmt.Errorf("failed to serialize Type_BIT: value %d overflows int64", u)
+	}
+
+	return int64(u), nil
 }
 
 func GetConverter(dataType fivetransdk.DataType) (ConverterFunc, error) {

--- a/cmd/internal/server/handlers/fivetran_value_converters_test.go
+++ b/cmd/internal/server/handlers/fivetran_value_converters_test.go
@@ -1,12 +1,14 @@
 package handlers
 
 import (
+	"math"
 	"testing"
 
 	fivetransdk "github.com/planetscale/fivetran-source/fivetran_sdk.v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 func TestJSONConverter_EmptyString(t *testing.T) {
@@ -36,4 +38,48 @@ func TestJSONConverter_ValidJSON(t *testing.T) {
 	json, ok := result.Inner.(*fivetransdk.ValueType_Json)
 	require.True(t, ok)
 	assert.Equal(t, `{"key": "value"}`, json.Json)
+}
+
+func TestLongConverter_BitValues(t *testing.T) {
+	converter, err := GetConverter(fivetransdk.DataType_LONG)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want int64
+	}{
+		{name: "zero", raw: []byte{0x00}, want: 0},
+		{name: "one", raw: []byte{0x01}, want: 1},
+		{name: "two", raw: []byte{0x02}, want: 2},
+		{name: "max seven bit", raw: []byte{0x7f}, want: 127},
+		{name: "eight bit high bit", raw: []byte{0x80}, want: 128},
+		{name: "eight bit max", raw: []byte{0xff}, want: 255},
+		{name: "two byte value", raw: []byte{0x01, 0x00}, want: 256},
+		{name: "max int64", raw: []byte{0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, want: math.MaxInt64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := converter(sqltypes.MakeTrusted(querypb.Type_BIT, tt.raw))
+			require.NoError(t, err)
+
+			got, ok := result.Inner.(*fivetransdk.ValueType_Long)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, got.Long)
+		})
+	}
+}
+
+func TestLongConverter_BitOverflow(t *testing.T) {
+	converter, err := GetConverter(fivetransdk.DataType_LONG)
+	require.NoError(t, err)
+
+	_, err = converter(sqltypes.MakeTrusted(querypb.Type_BIT, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overflows int64")
+
+	_, err = converter(sqltypes.MakeTrusted(querypb.Type_BIT, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uses 9 bytes")
 }


### PR DESCRIPTION
## Summary
- decode Vitess BIT raw bytes as unsigned big-endian values instead of signed varints
- return clear errors when BIT values cannot fit the signed Fivetran LONG representation
- add focused converter coverage for one-byte, multibyte, high-bit, and overflow cases

## Evidence
Vitess exposes MySQL BIT columns as querypb.Type_BIT and VStream row values carry the raw bit bytes. In upstream Vitess, BIT is not an integral sqltypes.Value, so this connector takes the raw-byte branch. Go binary.Varint decodes a different signed varint format, causing values like 0x01, 0x80, and 0xff to serialize incorrectly or fail.

## Validation
- GOCACHE=/tmp/fivetran-bugbash.qcjUz1/gocache go test ./cmd/internal/server/handlers
- git diff --check