### PR TITLE
Parse enum and set values with Vitess

### DIFF
--- a/cmd/internal/server/handlers/schema_builder.go
+++ b/cmd/internal/server/handlers/schema_builder.go
@@ -9,6 +9,8 @@ import (
 	"github.com/planetscale/fivetran-source/lib"
 
 	fivetransdk "github.com/planetscale/fivetran-source/fivetran_sdk.v2"
+	vtschema "vitess.io/vitess/go/vt/schema"
+	"vitess.io/vitess/go/vt/vtenv"
 )
 
 const (
@@ -32,7 +34,16 @@ type SchemaWithMetadata struct {
 var (
 	gcTableNameRegexp = regexp.MustCompile(gCTableNameExpression)
 	vreplRegex        = regexp.MustCompile(vreplTableNameExpression)
+	enumSetParserEnv  = newEnumSetParserEnv()
 )
+
+func newEnumSetParserEnv() *vtenv.Environment {
+	env, err := vtenv.New(vtenv.Options{})
+	if err != nil {
+		return vtenv.NewTestEnv()
+	}
+	return env
+}
 
 type FiveTranSchemaBuilder struct {
 	schemas               map[string]*fivetransdk.Schema
@@ -205,14 +216,17 @@ func isEnumOrSet(mType string) bool {
 // Takes enum or set column type like ENUM('a','b','c') or SET('a','b','c')
 // and returns a slice of values []string{'a', 'b', 'c'}
 func parseEnumOrSetValues(mType string) ValueMap {
-	values := []string{}
-	var columnType string
-	if strings.HasPrefix(mType, "enum") {
-		columnType = "enum"
-	} else if strings.HasPrefix(mType, "set") {
-		columnType = "set"
+	columnType, rawValues, ok := enumOrSetTypeAndRawValues(mType)
+	if ok {
+		if values, err := parseEnumOrSetTokens(rawValues); err == nil {
+			return ValueMap{
+				columnType: columnType,
+				values:     values,
+			}
+		}
 	}
 
+	values := []string{}
 	re := regexp.MustCompile(`\((.+)\)`)
 	res := re.FindString(mType)
 	res = strings.Trim(res, "(")
@@ -225,6 +239,39 @@ func parseEnumOrSetValues(mType string) ValueMap {
 		columnType: columnType,
 		values:     values,
 	}
+}
+
+func enumOrSetTypeAndRawValues(mType string) (string, string, bool) {
+	mysqlType := strings.ToLower(strings.TrimSpace(mType))
+	var columnType string
+	if strings.HasPrefix(mysqlType, "enum") {
+		columnType = "enum"
+	} else if strings.HasPrefix(mysqlType, "set") {
+		columnType = "set"
+	} else {
+		return "", "", false
+	}
+
+	begin := strings.Index(mType, "(")
+	end := strings.LastIndex(mType, ")")
+	if begin == -1 || end <= begin {
+		return columnType, "", false
+	}
+
+	return columnType, mType[begin+1 : end], true
+}
+
+func parseEnumOrSetTokens(rawValues string) ([]string, error) {
+	tokensMap, err := vtschema.ParseEnumOrSetTokensMap(enumSetParserEnv, rawValues)
+	if err != nil {
+		return nil, err
+	}
+
+	values := make([]string, 0, len(tokensMap))
+	for i := 1; i <= len(tokensMap); i++ {
+		values = append(values, tokensMap[i])
+	}
+	return values, nil
 }
 
 // Convert columnType to fivetran type

--- a/cmd/internal/server/handlers/schema_builder_test.go
+++ b/cmd/internal/server/handlers/schema_builder_test.go
@@ -116,6 +116,42 @@ func TestCanBuildUpdateSchema(t *testing.T) {
 	assert.Equal(t, enumsAndSets["Employees"]["departments"]["dept_locations"].columnType, "set")
 }
 
+func TestParseEnumOrSetValuesHandlesSQLStringLiterals(t *testing.T) {
+	tests := []struct {
+		name       string
+		mysqlType  string
+		columnType string
+		values     []string
+	}{
+		{
+			name:       "enum with comma",
+			mysqlType:  "enum('small','with,comma','large')",
+			columnType: "enum",
+			values:     []string{"small", "with,comma", "large"},
+		},
+		{
+			name:       "enum with escaped quote",
+			mysqlType:  "enum('plain','owner''s choice','other')",
+			columnType: "enum",
+			values:     []string{"plain", "owner's choice", "other"},
+		},
+		{
+			name:       "set with comma and escaped quote",
+			mysqlType:  "set('read','write,admin','owner''s choice')",
+			columnType: "set",
+			values:     []string{"read", "write,admin", "owner's choice"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseEnumOrSetValues(tt.mysqlType)
+			assert.Equal(t, tt.columnType, got.columnType)
+			assert.Equal(t, tt.values, got.values)
+		})
+	}
+}
+
 func TestSchema_CanPickRightFivetranType(t *testing.T) {
 	tests := []struct {
 		MysqlType             string

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/safehtml v0.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect


### PR DESCRIPTION
## Summary
- parse enum/set column value lists using Vitess' SQL literal parser instead of splitting on commas
- preserve the existing parser as a fallback for unexpected column type strings
- add coverage for commas and escaped quotes inside enum/set literals

## Evidence
MySQL enum/set labels can contain commas and escaped quotes. The old parser split the raw column_type string on every comma, so schema metadata for values like enum('small','with,comma') was wrong. Vitess already parses these column definitions for VStream enum/set mapping, and the connector already depends on Vitess.

## Validation
- GOCACHE=/tmp/fivetran-bugbash.qcjUz1/gocache go test ./cmd/internal/server/handlers -run 'Test(ParseEnumOrSetValuesHandlesSQLStringLiterals|CanBuildUpdateSchema)$'
- GOCACHE=/tmp/fivetran-bugbash.qcjUz1/gocache go test ./cmd/internal/server/handlers
- GOCACHE=/tmp/fivetran-bugbash.qcjUz1/gocache go test ./...
- git diff --check