### PR TITLE
Validate SET bitmask conversion

### DIFF
--- a/cmd/internal/server/handlers/fivetran_value_converters.go
+++ b/cmd/internal/server/handlers/fivetran_value_converters.go
@@ -274,30 +274,26 @@ func GetEnumConverter(enumValues []string) (ConverterFunc, error) {
 func GetSetConverter(setValues []string) (ConverterFunc, error) {
 	return func(value sqltypes.Value) (*fivetransdk.ValueType, error) {
 		parsedValue := value.ToString()
-		parsedInt, err := strconv.ParseInt(parsedValue, 10, 64)
+		parsedInt, err := strconv.ParseUint(parsedValue, 10, 64)
 		if err != nil {
-			// if value is not an integer, we just serialize as a strong
+			// if value is not an integer, we just serialize as a string
 			return &fivetransdk.ValueType{
 				Inner: &fivetransdk.ValueType_Json{Json: CleanStringValue(parsedValue)},
 			}, nil
 		}
 		mappedValues := []string{}
-		// SET mapping is stored as a binary value, i.e. 1001
-		bytes := strconv.FormatInt(parsedInt, 2)
-		numValues := len(bytes)
-		// if the bit is ON, that means the value at that index is included in the SET
-		for i, char := range bytes {
-			if char == '1' {
-				// bytes are in reverse order, the first bit represents the last value in the SET
-				mappedValue := setValues[numValues-(i+1)]
-				mappedValues = append([]string{mappedValue}, mappedValues...)
+		for idx, mask := 0, parsedInt; mask > 0; idx, mask = idx+1, mask>>1 {
+			if mask&1 == 1 {
+				if idx >= len(setValues) {
+					return nil, fmt.Errorf("failed to serialize Type_SET: bit %d has no mapped value", idx+1)
+				}
+				mappedValues = append(mappedValues, setValues[idx])
 			}
 		}
 
-		// If we can't find the values, just serialize as a string
 		if len(mappedValues) == 0 {
 			return &fivetransdk.ValueType{
-				Inner: &fivetransdk.ValueType_Json{Json: CleanStringValue(parsedValue)},
+				Inner: &fivetransdk.ValueType_Json{Json: ""},
 			}, nil
 		}
 

--- a/cmd/internal/server/handlers/fivetran_value_converters_test.go
+++ b/cmd/internal/server/handlers/fivetran_value_converters_test.go
@@ -9,6 +9,51 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 )
 
+func TestSetConverter_BitmaskValues(t *testing.T) {
+	converter, err := GetSetConverter([]string{"read", "write", "delete", "admin"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty set", value: "0", want: ""},
+		{name: "first value", value: "1", want: "read"},
+		{name: "first two values", value: "3", want: "read,write"},
+		{name: "fourth value", value: "8", want: "admin"},
+		{name: "non numeric string value", value: "read,write", want: "read,write"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := converter(sqltypes.NewVarChar(tt.value))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result.GetJson())
+		})
+	}
+}
+
+func TestSetConverter_ParsesUint64Masks(t *testing.T) {
+	setValues := make([]string, 64)
+	setValues[63] = "slot64"
+	converter, err := GetSetConverter(setValues)
+	require.NoError(t, err)
+
+	result, err := converter(sqltypes.NewVarChar("9223372036854775808"))
+	require.NoError(t, err)
+	assert.Equal(t, "slot64", result.GetJson())
+}
+
+func TestSetConverter_UnmappedBitReturnsError(t *testing.T) {
+	converter, err := GetSetConverter([]string{"read", "write"})
+	require.NoError(t, err)
+
+	_, err = converter(sqltypes.NewVarChar("4"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bit 3 has no mapped value")
+}
+
 func TestJSONConverter_EmptyString(t *testing.T) {
 	converter, err := GetConverter(fivetransdk.DataType_JSON)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- parse numeric SET masks as uint64 instead of signed int64
- walk SET bitmap bits directly and preserve declaration order
- return an explicit error when a numeric mask references an unmapped SET value instead of panicking
- serialize numeric zero as the empty SET value

## Evidence
The previous converter formatted the numeric mask as binary text and indexed setValues without bounds checks. A mask with a set bit beyond the parsed metadata could panic, and valid 64-bit SET masks above MaxInt64 were treated as raw strings. Vitess handles SET masks as unsigned 64-bit bitmaps and errors on unmapped bits.

## Validation
- GOCACHE=/tmp/fivetran-bugbash.qcjUz1/gocache go test ./cmd/internal/server/handlers -run 'TestSetConverter'
- GOCACHE=/tmp/fivetran-bugbash.qcjUz1/gocache go test ./cmd/internal/server/handlers
- git diff --check