### PR TITLE
Return read errors with VStream schema guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ test-ci: proto
 
 .PHONY: test-integration
 test-integration: proto
-	@go test -tags=integration -run TestIntegration -count=1 -v ./cmd/internal/server/handlers
+	@go test -tags=integration -run TestIntegration -count=1 -timeout 20m -v ./cmd/internal/server/handlers
 
 .PHONY: test-integration-stress
 test-integration-stress: proto
-	@INTEGRATION_STRESS=1 go test -tags=integration -run TestIntegration -count=1 -v ./cmd/internal/server/handlers
+	@INTEGRATION_STRESS=1 go test -tags=integration -run TestIntegration -count=1 -timeout 20m -v ./cmd/internal/server/handlers
 
 .PHONY: build
 build: proto/connector_sdk.proto

--- a/cmd/internal/server/handlers/integration_test.go
+++ b/cmd/internal/server/handlers/integration_test.go
@@ -18,6 +18,8 @@ import (
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	fivetransdk "github.com/planetscale/fivetran-source/fivetran_sdk.v2"
 	"github.com/planetscale/fivetran-source/lib"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -299,6 +301,63 @@ func TestIntegrationRepeatedSyncBursts(t *testing.T) {
 	}
 }
 
+func TestIntegrationMidTableDDLRequiresHistoricalResync(t *testing.T) {
+	psc := loadIntegrationSource(t)
+	ctx := context.Background()
+	tableName := integrationTableName(t)
+
+	db := openIntegrationSQL(t, psc)
+	t.Cleanup(func() {
+		if _, err := db.ExecContext(context.Background(), "drop table if exists "+quoteIdent(tableName)); err != nil {
+			t.Logf("drop integration table %s: %v", tableName, err)
+		}
+		_ = db.Close()
+	})
+
+	mustExec(t, ctx, db, fmt.Sprintf(`
+		create table %s (
+			id bigint primary key,
+			before_col varchar(64) not null,
+			after_col varchar(64) not null
+		)`, quoteIdent(tableName)))
+
+	columns := []string{"id", "before_col", "after_col"}
+	_, state := runIntegrationSync(t, psc, tableName, columns, nil)
+
+	mustExec(t, ctx, db, fmt.Sprintf(
+		"insert into %s (id, before_col, after_col) values (1, 'before-old', 'after-old')",
+		quoteIdent(tableName),
+	))
+	mustExec(t, ctx, db, fmt.Sprintf(
+		"alter table %s add column middle_col varchar(64) null after before_col",
+		quoteIdent(tableName),
+	))
+	mustExec(t, ctx, db, fmt.Sprintf(
+		"insert into %s (id, before_col, middle_col, after_col) values (2, 'before-new', 'middle-new', 'after-new')",
+		quoteIdent(tableName),
+	))
+
+	sender, failedState, err := runIntegrationSyncWithError(t, psc, tableName, columns, state)
+	if err == nil {
+		t.Fatalf("expected mid-table DDL to require a historical re-sync")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %s: %v", got, err)
+	}
+	for _, want := range []string{"historical re-sync", "failed to build table replication plan"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+	assertIntegrationRecordCount(t, sender.recordsForTable(tableName), 0)
+	if _, ok := sender.latestState(t); ok {
+		t.Fatalf("failed sync should not checkpoint state")
+	}
+	if !reflect.DeepEqual(state, failedState) {
+		t.Fatalf("failed sync changed state")
+	}
+}
+
 func TestIntegrationStressBurstLoad(t *testing.T) {
 	if !integrationStressEnabled() {
 		t.Skip("set INTEGRATION_STRESS=1 to run stress integration tests")
@@ -463,6 +522,16 @@ func openIntegrationSQL(t *testing.T, psc lib.PlanetScaleSource) *sql.DB {
 func runIntegrationSync(t *testing.T, psc lib.PlanetScaleSource, tableName string, columns []string, state *lib.SyncState) (*integrationSender, *lib.SyncState) {
 	t.Helper()
 
+	sender, state, err := runIntegrationSyncWithError(t, psc, tableName, columns, state)
+	if err != nil {
+		t.Fatalf("run sync: %v", err)
+	}
+	return sender, state
+}
+
+func runIntegrationSyncWithError(t *testing.T, psc lib.PlanetScaleSource, tableName string, columns []string, state *lib.SyncState) (*integrationSender, *lib.SyncState, error) {
+	t.Helper()
+
 	mysqlClient, err := lib.NewMySQL(&psc)
 	if err != nil {
 		t.Fatalf("create mysql client: %v", err)
@@ -504,12 +573,12 @@ func runIntegrationSync(t *testing.T, psc lib.PlanetScaleSource, tableName strin
 	logger := NewSchemaAwareSerializer(sender, "integration", psc.TreatTinyIntAsBoolean, sourceSchema.SchemaList, sourceSchema.EnumsAndSets)
 	syncer := &Sync{}
 	if err := syncer.Handle(&psc, &connectClient, logger, state, selection); err != nil {
-		t.Fatalf("run sync: %v", err)
+		return sender, state, err
 	}
 	if checkpoint, ok := sender.latestState(t); ok {
 		state = checkpoint
 	}
-	return sender, state
+	return sender, state, nil
 }
 
 func integrationSelection(schemaName, tableName string, columns []string) *fivetransdk.Selection_WithSchema {

--- a/cmd/internal/server/handlers/sync.go
+++ b/cmd/internal/server/handlers/sync.go
@@ -80,6 +80,9 @@ func (s *Sync) Handle(psc *lib.PlanetScaleSource, db *lib.ConnectClient, logger 
 				columns := includedColumns(table)
 				sc, err := (*db).Read(ctx, logger, *psc, table.TableName, columns, tc, onRow, onCursor, onUpdate)
 				if err != nil {
+					if lib.IsVStreamSchemaIncompatibilityError(err) {
+						return status.Error(codes.FailedPrecondition, err.Error())
+					}
 					return status.Error(codes.Internal, fmt.Sprintf("failed to download rows for table : %s , error : %s", table.TableName, err.Error()))
 				}
 				if sc != nil {

--- a/cmd/internal/server/handlers/sync_test.go
+++ b/cmd/internal/server/handlers/sync_test.go
@@ -9,6 +9,8 @@ import (
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	fivetransdk "github.com/planetscale/fivetran-source/fivetran_sdk.v2"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestCallsReadWithSelectedSchema(t *testing.T) {
@@ -171,4 +173,49 @@ func TestCallsReadWithStartingGtids(t *testing.T) {
 		},
 	}, schemaSelection)
 	assert.NoError(t, err)
+}
+
+func TestVStreamSchemaIncompatibilityReturnsFailedPrecondition(t *testing.T) {
+	psc := &lib.PlanetScaleSource{}
+	tl := &testLogger{}
+	schema := fivetransdk.SchemaSelection{
+		SchemaName: "SalesDB",
+		Included:   true,
+		Tables: []*fivetransdk.TableSelection{
+			{
+				Included:  true,
+				TableName: "customers",
+			},
+		},
+	}
+	schemaSelection := &fivetransdk.Selection_WithSchema{
+		WithSchema: &fivetransdk.TablesWithSchema{
+			Schemas: []*fivetransdk.SchemaSelection{
+				&schema,
+			},
+		},
+	}
+
+	readFn := func(ctx context.Context, logger lib.DatabaseLogger, ps lib.PlanetScaleSource, tableName string, columns []string,
+		tc *psdbconnect.TableCursor, onResult lib.OnResult, onCursor lib.OnCursor, onUpdate lib.OnUpdate,
+	) (*lib.SerializedCursor, error) {
+		return nil, status.Error(codes.Unknown, "Code: FAILED_PRECONDITION\n"+
+			"column after_col not found in table customers\n\n"+
+			"failed to build table replication plan for table customers")
+	}
+
+	state, err := psc.GetInitialState("SalesDB", []string{"-"})
+	assert.NoError(t, err)
+	db := lib.NewTestConnectClient(readFn)
+	err = (&Sync{}).Handle(psc, &db, tl, &lib.SyncState{
+		Keyspaces: map[string]lib.KeyspaceState{
+			"SalesDB": {
+				Streams: map[string]lib.ShardStates{
+					"SalesDB:customers": state,
+				},
+			},
+		},
+	}, schemaSelection)
+	assert.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 }

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -18,6 +18,7 @@ import (
 	clientoptions "github.com/planetscale/psdb/core/pool/options"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/sqltypes"
 
@@ -154,7 +155,7 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 			if s, ok := status.FromError(err); ok {
 				// if the error is anything other than server timeout, keep going
 				if s.Code() != codes.DeadlineExceeded {
-					logger.Warning(fmt.Sprintf("%vGot error [%v] with message [%q], Returning with cursor :[%v] after non-timeout error", preamble, s.Code(), err, currentPosition))
+					logger.Warning(fmt.Sprintf("%vGot error [%v] with message [%q], returning error with cursor :[%v] after non-timeout error", preamble, s.Code(), err, currentPosition))
 
 					// Check for binlog expiration error and reset cursor for historical sync
 					if IsBinlogsExpirationError(err) {
@@ -175,7 +176,11 @@ func (p connectClient) Read(ctx context.Context, logger DatabaseLogger, ps Plane
 						continue
 					}
 
-					return currentSerializedCursor, nil
+					if IsVStreamSchemaIncompatibilityError(err) {
+						return currentSerializedCursor, errors.Wrapf(err, "PlanetScale VStream cannot continue incremental replication for table %s after a schema change; run a Fivetran historical re-sync for this connection to recover", tableName)
+					}
+
+					return currentSerializedCursor, err
 				} else {
 					consecutiveTimeouts++
 					logger.Info(fmt.Sprintf("%sTimeout occurred (%d/%d consecutive timeouts)", preamble, consecutiveTimeouts, maxConsecutiveTimeouts))
@@ -271,6 +276,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 	if tc.LastKnownPk != nil {
 		tc.Position = ""
 	}
+	syncStartCursor := cloneTableCursor(tc)
 
 	logger.Info(fmt.Sprintf("%sSyncing with cursor position : [%v], using last known PK : %v, stop cursor is : [%v]", preamble, tc.Position, tc.LastKnownPk != nil, stopPosition))
 
@@ -308,7 +314,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 					}
 					sqlResult.Rows = append(sqlResult.Rows, row)
 					if err := onResult(sqlResult, OpType_Insert); err != nil {
-						return tc, status.Error(codes.Internal, "unable to serialize row")
+						return syncStartCursor, status.Error(codes.Internal, "unable to serialize row")
 					}
 				}
 			}
@@ -321,7 +327,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 					}
 					sqlResult.Rows = append(sqlResult.Rows, row)
 					if err := onResult(sqlResult, OpType_Delete); err != nil {
-						return nil, status.Error(codes.Internal, "unable to serialize row")
+						return syncStartCursor, status.Error(codes.Internal, "unable to serialize row")
 					}
 				}
 			}
@@ -334,7 +340,7 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 					After:  serializeQueryResult(update.After),
 				}
 				if err := onUpdate(updatedRow); err != nil {
-					return nil, status.Error(codes.Internal, "unable to serialize update")
+					return syncStartCursor, status.Error(codes.Internal, "unable to serialize update")
 				}
 			}
 		}
@@ -357,6 +363,13 @@ func (p connectClient) sync(ctx context.Context, logger DatabaseLogger, tableNam
 			return tc, io.EOF
 		}
 	}
+}
+
+func cloneTableCursor(tc *psdbconnect.TableCursor) *psdbconnect.TableCursor {
+	if tc == nil {
+		return nil
+	}
+	return proto.Clone(tc).(*psdbconnect.TableCursor)
 }
 
 func (p connectClient) filterExistingColumns(ctx context.Context, ps PlanetScaleSource, tableName string, columns []string) ([]string, error) {
@@ -456,4 +469,21 @@ func IsBinlogsExpirationError(err error) bool {
 		return false
 	}
 	return strings.Contains(err.Error(), "Cannot replicate because the source purged required binary logs")
+}
+
+func IsVStreamSchemaIncompatibilityError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, "Code: FAILED_PRECONDITION") {
+		return false
+	}
+	if !strings.Contains(message, "failed to build table replication plan") {
+		return false
+	}
+
+	return strings.Contains(message, "cannot use column names in vstream filter") ||
+		(strings.Contains(message, "column ") && strings.Contains(message, " not found in table "))
 }

--- a/lib/connect_client_test.go
+++ b/lib/connect_client_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"vitess.io/vitess/go/sqltypes"
 )
@@ -259,6 +261,216 @@ func TestRead_CanReturnNewCursorIfNewFound(t *testing.T) {
 	assert.Equal(t, 2, cc.syncFnInvokedCount)
 }
 
+func TestRead_ReturnsVStreamSchemaIncompatibilityErrors(t *testing.T) {
+	dbl := &dbLogger{}
+	ped := connectClient{}
+	tc := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "THIS_IS_A_SHARD_GTID",
+		Keyspace: "connect-test",
+	}
+	stopCursor := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "I_AM_THE_CURRENT_BINLOG_POSITION",
+		Keyspace: "connect-test",
+	}
+
+	getCurrentVGtidClient := &connectSyncClientMock{
+		syncResponses: []*psdbconnect.SyncResponse{
+			{Cursor: stopCursor},
+		},
+	}
+
+	cc := clientConnectionMock{
+		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
+			if in.Cursor.Position == "current" {
+				return getCurrentVGtidClient, nil
+			}
+			return nil, status.Error(codes.Unknown, vstreamColumnNotFoundErrorMessage)
+		},
+	}
+	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
+		return &cc, nil
+	}
+	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+		return []MysqlColumn{
+			{Name: "id", Type: "bigint", IsPrimaryKey: true},
+			{Name: "before_col", Type: "varchar(64)", IsPrimaryKey: false},
+			{Name: "after_col", Type: "varchar(64)", IsPrimaryKey: false},
+		}, nil
+	}
+	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+	ped.Mysql = &mysqlClient
+
+	sc, err := ped.Read(context.Background(), dbl, PlanetScaleSource{Database: "connect-test"}, "customers", []string{"id", "before_col", "after_col"}, tc, nil, nil, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "historical re-sync")
+	assert.True(t, IsVStreamSchemaIncompatibilityError(err))
+	esc, err := TableCursorToSerializedCursor(tc)
+	assert.NoError(t, err)
+	assert.Equal(t, esc, sc)
+	assert.Equal(t, 2, cc.syncFnInvokedCount)
+}
+
+func TestRead_ReturnsGenericNonTimeoutErrors(t *testing.T) {
+	dbl := &dbLogger{}
+	ped := connectClient{}
+	tc := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "THIS_IS_A_SHARD_GTID",
+		Keyspace: "connect-test",
+	}
+	stopCursor := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "I_AM_THE_CURRENT_BINLOG_POSITION",
+		Keyspace: "connect-test",
+	}
+
+	getCurrentVGtidClient := &connectSyncClientMock{
+		syncResponses: []*psdbconnect.SyncResponse{
+			{Cursor: stopCursor},
+		},
+	}
+
+	cc := clientConnectionMock{
+		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
+			if in.Cursor.Position == "current" {
+				return getCurrentVGtidClient, nil
+			}
+			return nil, status.Error(codes.Unavailable, "tablet unavailable")
+		},
+	}
+	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
+		return &cc, nil
+	}
+	getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+		return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}}, nil
+	}
+	mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+	ped.Mysql = &mysqlClient
+
+	sc, err := ped.Read(context.Background(), dbl, PlanetScaleSource{Database: "connect-test"}, "customers", []string{"id"}, tc, nil, nil, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tablet unavailable")
+	assert.NotContains(t, err.Error(), "historical re-sync")
+	assert.False(t, IsVStreamSchemaIncompatibilityError(err))
+	esc, err := TableCursorToSerializedCursor(tc)
+	assert.NoError(t, err)
+	assert.Equal(t, esc, sc)
+	assert.Equal(t, 2, cc.syncFnInvokedCount)
+}
+
+func TestRead_CallbackErrorsReturnStartCursor(t *testing.T) {
+	testFields := sqltypes.MakeTestFields("pid|description", "int64|varbinary")
+
+	tests := []struct {
+		name         string
+		response     *psdbconnect.SyncResponse
+		onRow        OnResult
+		onUpdate     OnUpdate
+		errorMessage string
+	}{
+		{
+			name: "insert callback",
+			response: &psdbconnect.SyncResponse{
+				Result: []*query.QueryResult{
+					sqltypes.ResultToProto3(sqltypes.MakeTestResult(testFields, "12|new_monitor")),
+				},
+			},
+			onRow: func(_ *sqltypes.Result, op Operation) error {
+				if op == OpType_Insert {
+					return errors.New("serialize failed")
+				}
+				return nil
+			},
+			errorMessage: "unable to serialize row",
+		},
+		{
+			name: "delete callback",
+			response: &psdbconnect.SyncResponse{
+				Deletes: []*psdbconnect.DeletedRow{
+					{
+						Result: sqltypes.ResultToProto3(sqltypes.MakeTestResult(testFields, "12|deleted_monitor")),
+					},
+				},
+			},
+			onRow: func(_ *sqltypes.Result, op Operation) error {
+				if op == OpType_Delete {
+					return errors.New("serialize failed")
+				}
+				return nil
+			},
+			errorMessage: "unable to serialize row",
+		},
+		{
+			name: "update callback",
+			response: &psdbconnect.SyncResponse{
+				Updates: []*psdbconnect.UpdatedRow{
+					{
+						Before: sqltypes.ResultToProto3(sqltypes.MakeTestResult(testFields, "12|old_monitor")),
+						After:  sqltypes.ResultToProto3(sqltypes.MakeTestResult(testFields, "12|new_monitor")),
+					},
+				},
+			},
+			onUpdate: func(*UpdatedRow) error {
+				return errors.New("serialize failed")
+			},
+			errorMessage: "unable to serialize update",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbl := &dbLogger{}
+			ped := connectClient{}
+			tc := &psdbconnect.TableCursor{
+				Shard:    "-",
+				Position: "THIS_IS_A_SHARD_GTID",
+				Keyspace: "connect-test",
+			}
+			newTC := &psdbconnect.TableCursor{
+				Shard:    "-",
+				Position: "I_AM_FARTHER_IN_THE_BINLOG",
+				Keyspace: "connect-test",
+			}
+
+			getCurrentVGtidClient := &connectSyncClientMock{
+				syncResponses: []*psdbconnect.SyncResponse{{Cursor: newTC}},
+			}
+			syncClient := &connectSyncClientMock{
+				syncResponses: []*psdbconnect.SyncResponse{
+					{Cursor: newTC},
+					tt.response,
+				},
+			}
+
+			cc := clientConnectionMock{
+				syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
+					if in.Cursor.Position == "current" {
+						return getCurrentVGtidClient, nil
+					}
+					return syncClient, nil
+				},
+			}
+			ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
+				return &cc, nil
+			}
+			getKeyspaceTableColumnsFunc := func(ctx context.Context, keyspaceName string, tableName string) ([]MysqlColumn, error) {
+				return []MysqlColumn{{Name: "id", Type: "bigint", IsPrimaryKey: true}}, nil
+			}
+			mysqlClient := NewTestMysqlClient(getKeyspaceTableColumnsFunc)
+			ped.Mysql = &mysqlClient
+
+			sc, err := ped.Read(context.Background(), dbl, PlanetScaleSource{Database: "connect-test"}, "customers", nil, tc, tt.onRow, nil, tt.onUpdate)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorMessage)
+			esc, err := TableCursorToSerializedCursor(tc)
+			assert.NoError(t, err)
+			assert.Equal(t, esc, sc)
+		})
+	}
+}
+
 func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 	dbl := &dbLogger{}
 	ped := connectClient{}
@@ -479,3 +691,46 @@ func TestRead_FiltersNonExistentColumns(t *testing.T) {
 		})
 	}
 }
+
+func TestIsVStreamSchemaIncompatibilityError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "column not found while building table replication plan",
+			err:  status.Error(codes.Unknown, vstreamColumnNotFoundErrorMessage),
+			want: true,
+		},
+		{
+			name: "synthetic table map column names",
+			err: status.Error(codes.Unknown, "stream error: Code: FAILED_PRECONDITION\n"+
+				"cannot use column names in vstream filter as the current table schema for table customers is not compatible with the current event for this table in the stream\n\n"+
+				"failed to build table replication plan for table customers"),
+			want: true,
+		},
+		{
+			name: "binlog expiration is not schema incompatibility",
+			err:  errors.New("Cannot replicate because the source purged required binary logs"),
+			want: false,
+		},
+		{
+			name: "generic failed precondition is not enough",
+			err:  status.Error(codes.Unknown, "Code: FAILED_PRECONDITION\nanother replication error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsVStreamSchemaIncompatibilityError(tt.err))
+		})
+	}
+}
+
+const vstreamColumnNotFoundErrorMessage = "error starting stream from shard GTID keyspace:\"fivetran\" shard:\"-\": persistent error in vstream: " +
+	"stream (at source tablet) error @ (including the GTID we failed to process): Code: FAILED_PRECONDITION\n" +
+	"column after_col not found in table customers\n\n" +
+	"failed to build table replication plan for table customers\n" +
+	"failed to parse transaction payload's internal event"


### PR DESCRIPTION
## Summary
- return non-timeout read errors instead of logging a warning and reporting sync success
- preserve the read-attempt start cursor when row/update serialization callbacks fail, so failed work does not advance state
- detect Vitess/VStream schema incompatibility errors while building a table replication plan after schema changes
- add a specific historical re-sync instruction and surface that schema case as gRPC FailedPrecondition
- add a real PlanetScale integration regression for mid-table DDL requiring historical re-sync

Closes #77.
Supersedes #78 and #87.

## Notes
This intentionally does not auto-reset state or perform a historical re-sync. If the VStream schema incompatibility condition is hit, continuing incremental replication cannot make progress safely and the user/operator should trigger a Fivetran historical re-sync. Generic non-timeout read errors now fail the sync as well, preserving the underlying error instead of silently dropping it.

## Tests
- env GOCACHE=/tmp/fivetran-go-build-cache go test ./...
- env GOCACHE=/tmp/fivetran-go-build-cache DATABASE_HOST=... DATABASE_NAME=... DATABASE_USERNAME=... DATABASE_PASSWORD=... go test -tags=integration ./cmd/internal/server/handlers -run TestIntegrationMidTableDDLRequiresHistoricalResync -count=1 -v
- env GOCACHE=/tmp/fivetran-go-build-cache DATABASE_HOST=... DATABASE_NAME=... DATABASE_USERNAME=... DATABASE_PASSWORD=... make test-integration-stress
