### PR TITLE
Recognise all recoverable schema incompatibilities in vstream plan failures

### DIFF
--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -946,7 +946,7 @@ func IsBinlogsExpirationError(err error) bool {
 // stream asked for. Recovery is the same in every case: drop the cursor and run
 // a historical sync.
 //
-// vstreamer wraps all variants with "failed to build table replication plan for
+// vstreamer wraps every variant with "failed to build table replication plan for
 // table <name>". The inner cause depends on the shape of the DDL:
 //
 //   - "column <c> not found in table <t>" — a column was appended and the stream
@@ -956,11 +956,26 @@ func IsBinlogsExpirationError(err error) bool {
 //     longer type-matches the event and only positional names are available.
 //   - "cannot determine table columns for <t>" — a column was dropped, so the
 //     current schema is narrower than the event.
+//   - "failed to build ENUM and SET column integer to string mappings" — an ENUM
+//     or SET column was dropped, so its value list can no longer be recovered to
+//     decode the integers in the event.
 //
-// The first two are raised through vterrors as FAILED_PRECONDITION. The
-// drop-column variant is a plain fmt.Errorf inside vstreamer and reaches us with
-// no gRPC code attached, so the code is deliberately not part of the match:
-// requiring it silently excluded every DROP COLUMN deploy.
+// Only the first two are raised through vterrors as FAILED_PRECONDITION; the
+// others are plain errors and reach us with no gRPC code attached, so the code is
+// deliberately not part of the match. Requiring it silently excluded every DROP
+// COLUMN deploy.
+//
+// The wrapper alone is not sufficient. Two other errors share it and are not
+// recoverable by re-syncing:
+//
+//   - "unsupported type: <n>, position: <i>" — a historical sync would hit the
+//     same unsupported column type.
+//   - "unknown table <t> in schema" — the tablet could not resolve the table at
+//     all. This is not a stale-cursor condition: a historian miss falls back to
+//     the live schema rather than erroring, so this indicates an undecodable GTID
+//     or a table genuinely absent from the tablet's schema, which can be
+//     transient during an online DDL rename swap. Resetting the cursor for a
+//     transient condition would force an unnecessary historical sync.
 func IsVStreamSchemaIncompatibilityError(err error) bool {
 	if err == nil {
 		return false
@@ -973,5 +988,6 @@ func IsVStreamSchemaIncompatibilityError(err error) bool {
 
 	return strings.Contains(message, "cannot use column names in vstream filter") ||
 		strings.Contains(message, "cannot determine table columns") ||
+		strings.Contains(message, "failed to build ENUM and SET column integer to string mappings") ||
 		(strings.Contains(message, "column ") && strings.Contains(message, " not found in table "))
 }

--- a/lib/connect_client.go
+++ b/lib/connect_client.go
@@ -940,19 +940,38 @@ func IsBinlogsExpirationError(err error) bool {
 	return strings.Contains(err.Error(), "Cannot replicate because the source purged required binary logs")
 }
 
+// IsVStreamSchemaIncompatibilityError reports whether err indicates that the
+// source tablet could not build a replication plan for a table because the
+// schema recorded in the binlog event no longer lines up with the columns this
+// stream asked for. Recovery is the same in every case: drop the cursor and run
+// a historical sync.
+//
+// vstreamer wraps all variants with "failed to build table replication plan for
+// table <name>". The inner cause depends on the shape of the DDL:
+//
+//   - "column <c> not found in table <t>" — a column was appended and the stream
+//     now requests it, but the event being replayed predates the ALTER.
+//   - "cannot use column names in vstream filter ..." — columns were inserted
+//     mid-table (ADD COLUMN ... AFTER) or reordered, so the truncated schema no
+//     longer type-matches the event and only positional names are available.
+//   - "cannot determine table columns for <t>" — a column was dropped, so the
+//     current schema is narrower than the event.
+//
+// The first two are raised through vterrors as FAILED_PRECONDITION. The
+// drop-column variant is a plain fmt.Errorf inside vstreamer and reaches us with
+// no gRPC code attached, so the code is deliberately not part of the match:
+// requiring it silently excluded every DROP COLUMN deploy.
 func IsVStreamSchemaIncompatibilityError(err error) bool {
 	if err == nil {
 		return false
 	}
 
 	message := err.Error()
-	if !strings.Contains(message, "Code: FAILED_PRECONDITION") {
-		return false
-	}
 	if !strings.Contains(message, "failed to build table replication plan") {
 		return false
 	}
 
 	return strings.Contains(message, "cannot use column names in vstream filter") ||
+		strings.Contains(message, "cannot determine table columns") ||
 		(strings.Contains(message, "column ") && strings.Contains(message, " not found in table "))
 }

--- a/lib/connect_client_test.go
+++ b/lib/connect_client_test.go
@@ -1489,9 +1489,27 @@ func TestIsVStreamSchemaIncompatibilityError(t *testing.T) {
 			want: true,
 		},
 		{
+			// Dropping an ENUM or SET column loses the value list needed to
+			// decode the integers in the replayed event.
+			name: "dropped enum column loses its string mappings",
+			err:  status.Error(codes.Unknown, vstreamEnumMappingErrorMessage),
+			want: true,
+		},
+		{
+			// Shares the wrapper but a historical sync would hit the same
+			// unsupported column type, so re-syncing cannot recover it.
 			name: "plan failure with an unrelated cause is not schema incompatibility",
 			err: status.Error(codes.Unknown, "stream (at source tablet) error: unsupported type: 245, position: 3\n\n"+
 				"failed to build table replication plan for table customers"),
+			want: false,
+		},
+		{
+			// Also shares the wrapper, but a historian miss falls back to the
+			// live schema rather than erroring, so this is not a stale-cursor
+			// condition. It can be transient during an online DDL rename swap,
+			// where resetting the cursor would force a needless historical sync.
+			name: "unresolvable table is not schema incompatibility",
+			err:  status.Error(codes.Unknown, vstreamUnknownTableErrorMessage),
 			want: false,
 		},
 	}
@@ -1533,4 +1551,21 @@ const vstreamColumnNotFoundErrorMessage = "error starting stream from shard GTID
 const vstreamDroppedColumnErrorMessage = "error starting stream from shard GTID keyspace:\"fivetran\" shard:\"-\": persistent error in vstream: " +
 	"stream (at source tablet) error @ (including the GTID we failed to process): \n" +
 	"cannot determine table columns for customers: event has [8 18 18 252 5 3], schema has [id before_col after_col]\n\n" +
+	"failed to build table replication plan for table customers"
+
+// Emitted when the tablet cannot resolve the table at all. Deliberately NOT
+// treated as a schema incompatibility: a historian miss falls back to the live
+// schema rather than erroring, so this does not indicate a stale cursor, and it
+// can be transient during an online DDL rename swap.
+const vstreamUnknownTableErrorMessage = "error starting stream from shard GTID keyspace:\"fivetran\" shard:\"-\": persistent error in vstream: " +
+	"stream (at source tablet) error @ (including the GTID we failed to process): \n" +
+	"unknown table customers in schema\n\n" +
+	"failed to build table replication plan for table customers"
+
+// Emitted after dropping an ENUM or SET column: the value list needed to decode
+// the integers in the replayed event is no longer recoverable.
+const vstreamEnumMappingErrorMessage = "error starting stream from shard GTID keyspace:\"fivetran\" shard:\"-\": persistent error in vstream: " +
+	"stream (at source tablet) error @ (including the GTID we failed to process): \n" +
+	"enum or set column status does not have valid string values: \n\n" +
+	"failed to build ENUM and SET column integer to string mappings\n\n" +
 	"failed to build table replication plan for table customers"

--- a/lib/connect_client_test.go
+++ b/lib/connect_client_test.go
@@ -1480,6 +1480,20 @@ func TestIsVStreamSchemaIncompatibilityError(t *testing.T) {
 			err:  status.Error(codes.Unknown, "Code: FAILED_PRECONDITION\nanother replication error"),
 			want: false,
 		},
+		{
+			// DROP COLUMN leaves the live schema narrower than the replayed
+			// event. vstreamer raises this with a plain fmt.Errorf, so unlike
+			// the other variants it carries no FAILED_PRECONDITION code.
+			name: "dropped column without a failed precondition code",
+			err:  status.Error(codes.Unknown, vstreamDroppedColumnErrorMessage),
+			want: true,
+		},
+		{
+			name: "plan failure with an unrelated cause is not schema incompatibility",
+			err: status.Error(codes.Unknown, "stream (at source tablet) error: unsupported type: 245, position: 3\n\n"+
+				"failed to build table replication plan for table customers"),
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1511,3 +1525,12 @@ const vstreamColumnNotFoundErrorMessage = "error starting stream from shard GTID
 	"column after_col not found in table customers\n\n" +
 	"failed to build table replication plan for table customers\n" +
 	"failed to parse transaction payload's internal event"
+
+// Emitted after a DROP COLUMN, when the live schema is narrower than the event
+// being replayed. Note the absence of a "Code: FAILED_PRECONDITION" annotation:
+// vstreamer raises this one with a plain fmt.Errorf rather than through
+// vterrors, so no gRPC code is attached.
+const vstreamDroppedColumnErrorMessage = "error starting stream from shard GTID keyspace:\"fivetran\" shard:\"-\": persistent error in vstream: " +
+	"stream (at source tablet) error @ (including the GTID we failed to process): \n" +
+	"cannot determine table columns for customers: event has [8 18 18 252 5 3], schema has [id before_col after_col]\n\n" +
+	"failed to build table replication plan for table customers"


### PR DESCRIPTION
## Problem

`IsVStreamSchemaIncompatibilityError` (added in #89) requires `Code: FAILED_PRECONDITION` in the error text.

vstreamer wraps *every* plan failure with `failed to build table replication plan for table <name>`, but the inner cause varies with the shape of the DDL — and only two are raised through `vterrors` with a code attached. The rest are plain `fmt.Errorf`, so they arrive code-less and the matcher rejects them on its very first check:

| Inner cause | Raised when | Has a code? | Matched before? |
|---|---|---|---|
| `column <c> not found in table <t>` | column appended, stream now requests it, event predates the ALTER | yes | yes |
| `cannot use column names in vstream filter ...` | columns inserted mid-table (`ADD COLUMN ... AFTER`) or reordered | yes | yes |
| `cannot determine table columns for <t>` | column dropped, schema narrower than the event | no | **no** |
| `failed to build ENUM and SET column integer to string mappings` | ENUM/SET column dropped, value list unrecoverable | no | **no** |

Two of the four were unmatched, and both have been seen in production. Each falls through to the generic error return, so the operator gets an opaque `Internal` error rather than the `FailedPrecondition` and the explicit "run a historical re-sync" guidance #89 added — precisely the situations that guidance exists for.

All four recover the same way: drop the cursor, run a historical sync.

## Change

Gate on the `failed to build table replication plan` wrapper — common to all variants — and enumerate the four recoverable inner causes. The `FAILED_PRECONDITION` check is removed rather than relaxed: it excluded real failure shapes while adding no selectivity the wrapper does not already provide.

## What is deliberately excluded

The wrapper is **not** sufficient on its own. Two other errors share it and are not recoverable by re-syncing. Both have negative tests:

- **`unsupported type: <n>, position: <i>`** — a historical sync would hit the same unsupported column type.
- **`unknown table <t> in schema`** — this one is worth spelling out, because it looks like a stale-cursor condition and isn't. `historian.GetTableForPos` returns `(nil, nil)` on a miss, and `Engine.GetTableForPos` then falls back to the live schema rather than erroring:

  ```go
  if mt != nil { return mt, nil }
  // We got nothing from the historian, which typically means that it's not enabled.
  // ... falls back to the live schema
  ```

  So the historian fails open, and this error instead means an undecodable GTID or a table genuinely absent from the tablet's schema. The latter can be **transient during an online DDL rename swap**, where resetting the cursor would force an unnecessary historical sync.

## Tests

Eight table-driven cases — four positive, four negative. The two newly matched positives were each verified to fail against the previous matcher.

`go test ./lib` passes. (`./cmd/...` needs `make proto` first, as CI does via `test-ci: proto`.)

## Relationship to #97

Independent, and they compose. #97 adds opt-in automatic recovery once a schema incompatibility is detected; this PR determines what counts as one. Either can merge first — but detection without #97 only improves the error message, and #97 without this one only auto-recovers from two of the four causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
